### PR TITLE
OpenLayers3/4 view for development

### DIFF
--- a/app-resources/src/main/resources/flyway/paikkis/V2_10__fix_findbycoordinates.sql
+++ b/app-resources/src/main/resources/flyway/paikkis/V2_10__fix_findbycoordinates.sql
@@ -1,0 +1,12 @@
+UPDATE portti_bundle SET startup = '{
+    "title": "FindByCoordinates",
+    "bundleinstancename": "findbycoordinates",
+    "bundlename": "findbycoordinates",
+    "metadata": {
+        "Import-Bundle": {
+            "findbycoordinates": {
+                "bundlePath": "/Oskari/packages/framework/bundle/"
+            }
+        }
+    }
+}' WHERE name = 'findbycoordinates';

--- a/app-resources/src/main/resources/json/views/paikkis-ol3-dev.json
+++ b/app-resources/src/main/resources/json/views/paikkis-ol3-dev.json
@@ -1,0 +1,156 @@
+{
+  "name": "Geoportal OL3",
+  "type": "USER",
+  "default": false,
+  "public": true,
+  "oskari": {
+    "application": "full-map",
+    "page": "index",
+    "development_prefix": "/applications/paikkatietoikkuna.fi"
+  },
+  "selectedLayers": [
+    "taustakartta.json"
+  ],
+  "bundles": [
+    {
+      "id": "mapfull",
+      "startup": {
+        "bundlename": "mapfull",
+        "metadata": {
+          "Import-Bundle": {
+            "mapwmts": {
+              "bundlePath": "/Oskari/packages/mapping/ol3/"
+            },
+            "mapwfs2": {
+              "bundlePath": "/Oskari/packages/mapping/ol3/"
+            },
+            "mapanalysis": {
+              "bundlePath": "/Oskari/packages/mapping/ol3/"
+            },
+            "mapuserlayers": {
+              "bundlePath": "/Oskari/packages/mapping/ol3/"
+            },
+            "maparcgis": {
+              "bundlePath": "/Oskari/packages/mapping/ol3/"
+            },
+            "mapstats": {
+              "bundlePath": "/Oskari/packages/mapping/ol3/"
+            },
+            "mapmodule": {
+              "bundlePath": "/Oskari/packages/mapping/ol3/"
+            },
+            "mapfull": {
+              "bundlePath": "/Oskari/packages/framework/bundle/"
+            },
+            "ui-components": {
+              "bundlePath": "/Oskari/packages/framework/bundle/"
+            },
+            "oskariui": {
+              "bundlePath": "/Oskari/packages/framework/bundle/"
+            }
+          }
+        }
+      }
+    },
+    { "id" : "divmanazer" },
+    {
+      "id": "toolbar",
+      "startup": {
+        "bundlename": "toolbar",
+        "metadata": {
+          "Import-Bundle": {
+            "toolbar": {
+              "bundlePath": "/Oskari/packages/mapping/ol3/"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "infobox",
+      "startup": {
+        "bundlename": "infobox",
+        "metadata": {
+          "Import-Bundle": {
+            "infobox": {
+              "bundlePath": "/Oskari/packages/mapping/ol3/"
+            }
+          }
+        }
+      }
+    },
+    { "id" : "statehandler" },
+    {
+      "id": "drawtools",
+      "startup": {
+        "bundlename": "drawtools",
+        "metadata": {
+          "Import-Bundle": {
+            "drawtools": {
+              "bundlePath": "/Oskari/packages/mapping/ol3/"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "routingService"
+    },
+    { "id" : "search" },
+    { "id" : "metadatacatalogue" },
+    { "id" : "layerselector2" },
+    { "id" : "layerselection2" },
+    { "id" : "coordinatedisplay" },
+    { "id" : "metadataflyout" },
+    {
+      "id": "routesearch",
+      "config" : {
+        "flyoutClazz": "Oskari.mapframework.bundle.routesearch.Flyout"
+      },
+      "startup" : {
+        "bundlename": "routesearch",
+        "metadata": {
+          "Import-Bundle": {
+            "routesearch": {
+              "bundlePath": "/Oskari/packages/paikkatietoikkuna/bundle/"
+            }
+          }
+        }
+      }
+    },
+    { "id" : "personaldata" },
+    { "id" : "publisher2" },
+    {
+      "id": "statsgrid",
+      "startup" : {
+        "bundlename": "statsgrid",
+        "metadata": {
+          "Import-Bundle": {
+            "geostats": {
+              "bundlePath": "/Oskari/packages/libraries/bundle/"
+            },
+            "statsgrid": {
+              "bundlePath": "/Oskari/packages/statistics/bundle/"
+            }
+          }
+        }
+      }
+    },
+    { "id" : "maplegend" },
+    { "id" : "userguide" },
+    { "id" : "myplaces2" },
+    { "id" : "printout" },
+    { "id" : "analyse" },
+    { "id" : "myplacesimport" },
+    { "id" : "featuredata2" },
+    { "id" : "heatmap" },
+    { "id" : "guidedtour" },
+    { "id" : "backendstatus" },
+    { "id" : "findbycoordinates" },
+    { "id" : "coordinatetool" },
+    { "id" : "timeseries" },
+    { "id" : "feedbackService" },
+    { "id" : "maprotator" },
+    { "id" : "system-message" }
+  ]
+}

--- a/server-extension/src/main/java/flyway/paikkis/V2_9__add_development_ol3_view.java
+++ b/server-extension/src/main/java/flyway/paikkis/V2_9__add_development_ol3_view.java
@@ -1,0 +1,56 @@
+package flyway.paikkis;
+
+import fi.nls.oskari.db.ViewHelper;
+import fi.nls.oskari.domain.map.view.Bundle;
+import fi.nls.oskari.domain.map.view.View;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.view.ViewService;
+import fi.nls.oskari.map.view.ViewServiceIbatisImpl;
+import fi.nls.oskari.util.PropertyUtil;
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+import org.json.JSONObject;
+
+import java.sql.Connection;
+
+public class V2_9__add_development_ol3_view implements JdbcMigration {
+
+    private static final Logger LOG = LogFactory.getLogger(V2_9__add_development_ol3_view.class);
+    private ViewService service = null;
+
+    public void migrate(Connection connection) throws Exception {
+        if(PropertyUtil.getOptional("flyway.paikkis.2_9.skip", true)) {
+            // skip by default
+            return;
+        }
+        service = new ViewServiceIbatisImpl();
+
+        final String file = PropertyUtil.get("flyway.paikkis.2_9.file", "paikkis-ol3-dev.json");
+        // configure the view that should be used as default options
+        final int defaultViewId = PropertyUtil.getOptional("flyway.paikkis.2_9.view", (int) service.getDefaultViewId());
+        try {
+            // load view from json and update startups for bundles
+            JSONObject json = ViewHelper.readViewFile(file);
+            View view = ViewHelper.createView(json);
+
+            View defaultView = service.getViewWithConf(defaultViewId);
+            for(Bundle bundle: defaultView.getBundles()) {
+                Bundle newBundle = view.getBundleByName(bundle.getName());
+                if(newBundle == null) {
+                    continue;
+                }
+                // copy the settings (state and config) from current default view
+                newBundle.setState(bundle.getState());
+                newBundle.setConfig(bundle.getConfig());
+            }
+            // save to db
+            service.addView(view);
+            LOG.info("Geoportal view with Openlayers 3 added with uuid", view.getUuid());
+        } catch (Exception e) {
+            LOG.warn(e, "Something went wrong while inserting the view!",
+                    "The update failed so to have an ol3 view you need to remove this update from the database table oskari_status_paikkis, " +
+                            "tune the template file:", file, " and restart the server to try again");
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
Migration that creates new view with OL3/4 versions of map module & bundles that have OL3/4 implementations. Config for bundles is copied from default view in the migration.

To run the migration you need to use the property:
flyway.paikkis.2_9.skip=false

To get the uuid of the view, you can run this SQL after starting the server:
SELECT uuid FROM portti_view WHERE name = 'Geoportal OL3';

The view has some bundles that still depend on OpenLayers2, and therefore the frontend app initialisation fails. This view is intended for developing/debugging the OL3/4 versions of these bundles.