### PR TITLE
Improvements to terrain profile service

### DIFF
--- a/service-terrain-profile/README.md
+++ b/service-terrain-profile/README.md
@@ -13,7 +13,7 @@ Requires following properties:
 
 property | description
 -------- | -----------
-`terrain.profile.wcs.endPoint` | URL of the WCS service, query string is NOT ALLOED (e.g. don't specify ?, otherwise it won't work)
+`terrain.profile.wcs.endPoint` | URL of the WCS service, query string is NOT ALLOWED (e.g. do NOT specify '?', otherwise it won't work)
 `terrain.profile.wcs.demCoverageId`| id of the DEM coverage in the WCS service
 
 Available parameters per request feature.properties.$key:

--- a/service-terrain-profile/src/main/java/fi/nls/paikkatietoikkuna/terrainprofile/DataPoint.java
+++ b/service-terrain-profile/src/main/java/fi/nls/paikkatietoikkuna/terrainprofile/DataPoint.java
@@ -4,10 +4,11 @@ public class DataPoint {
 
     private double e;
     private double n;
-    private double altitude;
     private double distFromStart;
-    private int tileIdx;
-    private int offsetInTile;
+    private int gridTileX;
+    private int gridTileY;
+    private int gridTileOffset;
+    private double altitude;
 
     public double getE() {
         return e;
@@ -25,14 +26,6 @@ public class DataPoint {
         this.n = n;
     }
 
-    public double getAltitude() {
-        return altitude;
-    }
-
-    public void setAltitude(double altitude) {
-        this.altitude = altitude;
-    }
-
     public double getDistFromStart() {
         return distFromStart;
     }
@@ -41,20 +34,36 @@ public class DataPoint {
         this.distFromStart = distFromStart;
     }
 
-    public int getTileIdx() {
-        return tileIdx;
+    public int getGridTileX() {
+        return gridTileX;
     }
 
-    public void setTileIdx(int tileIdx) {
-        this.tileIdx = tileIdx;
+    public void setGridTileX(int gridTileX) {
+        this.gridTileX = gridTileX;
     }
 
-    public int getOffsetInTile() {
-        return offsetInTile;
+    public int getGridTileY() {
+        return gridTileY;
     }
 
-    public void setOffsetInTile(int offsetInTile) {
-        this.offsetInTile = offsetInTile;
+    public void setGridTileY(int gridTileY) {
+        this.gridTileY = gridTileY;
+    }
+
+    public int getGridTileOffset() {
+        return gridTileOffset;
+    }
+
+    public void setGridTileOffset(int gridTileOffset) {
+        this.gridTileOffset = gridTileOffset;
+    }
+
+    public double getAltitude() {
+        return altitude;
+    }
+
+    public void setAltitude(double altitude) {
+        this.altitude = altitude;
     }
 
 }

--- a/service-terrain-profile/src/main/java/fi/nls/paikkatietoikkuna/terrainprofile/TerrainProfileHandler.java
+++ b/service-terrain-profile/src/main/java/fi/nls/paikkatietoikkuna/terrainprofile/TerrainProfileHandler.java
@@ -55,9 +55,6 @@ public class TerrainProfileHandler extends ActionHandler {
         Feature route = parseFeature(routeStr);
         LineString geom = (LineString) route.getGeometry();
         double[] points = GeoJSONHelper.getCoordinates2D(geom);
-        if (points.length / 2 > NUM_POINTS_MAX) {
-            throw new ActionParamsException("Too many coordinates, maximum is " + NUM_POINTS_MAX);
-        }
         int numPoints = Math.min(getNumPoints(route), NUM_POINTS_MAX);
         // double resolution = getResolution(route);
 
@@ -95,7 +92,18 @@ public class TerrainProfileHandler extends ActionHandler {
         try {
             Feature route = om.readValue(routeStr, Feature.class);
             if (!(route.getGeometry() instanceof LineString)) {
-                throw new ActionParamsException("Invalid input - expected LineString geometry");
+                throw new ActionParamsException("Invalid input"
+                        + " - expected LineString geometry");
+            }
+            LineString ls = (LineString) route.getGeometry();
+            int numPoints = ls.getCoordinates().size();
+            if (numPoints < 2) {
+                throw new ActionParamsException("Invalid input"
+                        + " - expected LineString with atleast two coordinates");
+            }
+            if (numPoints > NUM_POINTS_MAX) {
+                throw new ActionParamsException("Invalid input"
+                        + " - too many coordinates, maximum is " + NUM_POINTS_MAX);
             }
             return route;
         } catch (IllegalArgumentException | IOException e) {

--- a/service-terrain-profile/src/main/java/fi/nls/paikkatietoikkuna/terrainprofile/TerrainProfileHandler.java
+++ b/service-terrain-profile/src/main/java/fi/nls/paikkatietoikkuna/terrainprofile/TerrainProfileHandler.java
@@ -33,7 +33,6 @@ public class TerrainProfileHandler extends ActionHandler {
     protected static final String JSON_PROPERTY_NUM_POINTS = "numPoints";
     protected static final String JSON_PROPERTY_DISTANCE_FROM_START = "distanceFromStart";
 
-    private static final int NUM_POINTS_DEFAULT = 100;
     private static final int NUM_POINTS_MAX = 1000;
 
     private final ObjectMapper om;
@@ -56,6 +55,9 @@ public class TerrainProfileHandler extends ActionHandler {
         Feature route = parseFeature(routeStr);
         LineString geom = (LineString) route.getGeometry();
         double[] points = GeoJSONHelper.getCoordinates2D(geom);
+        if (points.length / 2 > NUM_POINTS_MAX) {
+            throw new ActionParamsException("Too many coordinates, maximum is " + NUM_POINTS_MAX);
+        }
         int numPoints = Math.min(getNumPoints(route), NUM_POINTS_MAX);
         // double resolution = getResolution(route);
 
@@ -122,7 +124,7 @@ public class TerrainProfileHandler extends ActionHandler {
     protected int getNumPoints(Feature route) throws ActionParamsException {
         Object numPoints = route.getProperty(JSON_PROPERTY_NUM_POINTS);
         if (numPoints == null) {
-            return NUM_POINTS_DEFAULT;
+            return 0;
         }
         if (numPoints instanceof Number) {
             return ((Number) numPoints).intValue();
@@ -134,7 +136,6 @@ public class TerrainProfileHandler extends ActionHandler {
         }
         throw new ActionParamsException(String.format(
                 "Invalid property value '%s'", JSON_PROPERTY_NUM_POINTS));
-
     }
 
 }

--- a/service-terrain-profile/src/main/java/fi/nls/paikkatietoikkuna/terrainprofile/TerrainProfileService.java
+++ b/service-terrain-profile/src/main/java/fi/nls/paikkatietoikkuna/terrainprofile/TerrainProfileService.java
@@ -17,6 +17,7 @@ import org.oskari.wcs.coverage.CoverageDescription;
 import org.oskari.wcs.coverage.RectifiedGridCoverage;
 import org.oskari.wcs.geotiff.IFD;
 import org.oskari.wcs.geotiff.TIFFReader;
+import org.oskari.wcs.gml.RectifiedGrid;
 import org.oskari.wcs.parser.CapabilitiesParser;
 import org.oskari.wcs.parser.CoverageDescriptionsParser;
 import org.oskari.wcs.request.DescribeCoverage;
@@ -27,39 +28,49 @@ import org.xml.sax.SAXException;
 public class TerrainProfileService {
 
     private static final String FORMAT_TIFF = "image/tiff";
-    private static final double STEP = 10.0;
 
     private final String endPoint;
-    private final String demCoverageId;
     private final Capabilities caps;
     private final RectifiedGridCoverage desc;
+    private final double originEast;
+    private final double originNorth;
+    private final double offsetVectorX;
+    private final double offsetVectorY;
 
-    public TerrainProfileService(String endPoint, String demCoverageId)
+    public TerrainProfileService(String endPoint, String coverageId)
             throws ServiceException {
         try {
             this.endPoint = endPoint;
-            this.demCoverageId = demCoverageId;
-            caps = getCapabilities();
-            CoverageDescription tmp = describeCoverage();
+            caps = getCapabilities(endPoint);
+            CoverageDescription tmp = describeCoverage(endPoint, coverageId);
             if (!(tmp instanceof RectifiedGridCoverage)) {
-                throw new ServiceException("Expected coverage to be of type RectifiedGridCoverage");
+                throw new ServiceException("Expected coverage of type RectifiedGridCoverage");
             }
             desc = (RectifiedGridCoverage) tmp;
+            RectifiedGrid grid = desc.getDomainSet();
+            originEast = grid.getOrigin().getPos()[0];
+            originNorth = grid.getOrigin().getPos()[1];
+            offsetVectorX = grid.getOffsetVectors()[0].getPos()[0];
+            offsetVectorY = grid.getOffsetVectors()[1].getPos()[1];
         } catch (IOException | ParserConfigurationException | SAXException e) {
             throw new ServiceException("Failed to initialize", e);
         }
     }
 
-    private Capabilities getCapabilities() throws IOException, ParserConfigurationException, SAXException {
-        String url = IOHelper.constructUrl(endPoint, GetCapabilities.toQueryParameters());
+    private Capabilities getCapabilities(String endPoint)
+            throws IOException, ParserConfigurationException, SAXException {
+        Map<String, String> params = GetCapabilities.toQueryParameters();
+        String url = IOHelper.constructUrl(endPoint, params);
         HttpURLConnection conn = IOHelper.getConnection(url);
         try (InputStream in = new BufferedInputStream(conn.getInputStream())) {
             return CapabilitiesParser.parse(in);
         }
     }
 
-    private CoverageDescription describeCoverage() throws IOException, ParserConfigurationException, SAXException {
-        String url = IOHelper.constructUrl(endPoint, DescribeCoverage.toQueryParameters(demCoverageId));
+    private CoverageDescription describeCoverage(String endPoint, String coverageId)
+            throws IOException, ParserConfigurationException, SAXException {
+        Map<String, String> params = DescribeCoverage.toQueryParameters(coverageId);
+        String url = IOHelper.constructUrl(endPoint, params);
         HttpURLConnection conn = IOHelper.getConnection(url);
         try (InputStream in = new BufferedInputStream(conn.getInputStream())) {
             return CoverageDescriptionsParser.parse(in).get(0);
@@ -75,23 +86,198 @@ public class TerrainProfileService {
      * @return
      *      array of array of floats
      */
-    public List<DataPoint> getTerrainProfile(double[] coordinates, int numPoints) throws ServiceException {
-        double[] envelope = GeomUtil.getEnvelope(coordinates);
-        // Round to nearest step
-        envelope[0] = STEP * Math.round(envelope[0] / STEP);
-        envelope[1] = STEP * Math.round(envelope[1] / STEP);
-        envelope[2] = STEP * Math.round(envelope[2] / STEP);
-        envelope[3] = STEP * Math.round(envelope[3] / STEP);
-        // TODO: Instead of using a single request we should split large envelopes
-        // to multiple requests with a reasonable maximum size (for example 256x256px)
+    public List<DataPoint> getTerrainProfile(double[] coordinates, int numPoints)
+            throws ServiceException {
+        if (coordinates.length / 2 < numPoints) {
+            coordinates = interpolate(coordinates, numPoints);
+        }
+        int gridTileSize = getGridTileSize(coordinates);
+        List<DataPoint> points = createDataPoints(coordinates, gridTileSize);
+        points.sort(new Comparator<DataPoint>() {
+            @Override
+            public int compare(DataPoint o1, DataPoint o2) {
+                int d = o1.getGridTileY() - o2.getGridTileY();
+                if (d != 0) {
+                    return d;
+                }
+                d = o1.getGridTileX() - o2.getGridTileX();
+                return d != 0 ? d : o1.getGridTileOffset() - o2.getGridTileOffset();
+            }
+        });
 
-        // Add one step extra to end, since the condition is interpreted as [start,end[
-        // Only change this for the request, not for the envelope,
-        // envelope is later used for calculating the coordinate<->pixel values
-        Map<String, String[]> getCoverageKVP = new GetCoverage(caps, desc, FORMAT_TIFF)
-            .subset("E", envelope[0], envelope[2] + STEP)
-            .subset("N", envelope[1], envelope[3] + STEP)
-            .toKVP();
+        int prevGridTileY = -1;
+        int prevGridTileX = -1;
+        int prevGridTileOff = -1;
+        float[] grid = null;
+        float altitude = 0f;
+
+        for (DataPoint point : points) {
+            int gridTileX = point.getGridTileX();
+            int gridTileY = point.getGridTileY();
+            int gridTileOff = point.getGridTileOffset();
+            if (prevGridTileX != gridTileX || prevGridTileY != gridTileY) {
+                 grid = getGrid(gridTileSize, gridTileX, gridTileY);
+                 prevGridTileOff = -1;
+                 prevGridTileX = gridTileX;
+                 prevGridTileY = gridTileY;
+            }
+            // Cache the altitude to a local variable, it might be needed multiple times
+            if (prevGridTileOff != gridTileOff) {
+                altitude = grid[gridTileOff];
+                prevGridTileOff = gridTileOff;
+            }
+            point.setAltitude(altitude);
+        }
+
+        points.sort(new Comparator<DataPoint>() {
+            @Override
+            public int compare(DataPoint o1, DataPoint o2) {
+                return Double.compare(o1.getDistFromStart(), o2.getDistFromStart());
+            }
+        });
+        return points;
+    }
+
+    private double[] interpolate(double[] coordinates, int numDataPoints) {
+        double[] interpolated = new double[numDataPoints * 2];
+
+        double segmentLength = GeomUtil.getLength(coordinates) / (numDataPoints - 1);
+        double remainingSegmentLength = segmentLength;
+
+        int i = 0;
+        int j = 0;
+
+        double x0 = coordinates[j++];
+        double y0 = coordinates[j++];
+        double x1 = coordinates[j++];
+        double y1 = coordinates[j++];
+        double dx = x1 - x0;
+        double dy = y1 - y0;
+        double len = Math.sqrt(dx * dx + dy * dy);
+
+        // First point
+        interpolated[i++] = x0;
+        interpolated[i++] = y0;
+
+        while (i < interpolated.length - 2) {
+            if (len < remainingSegmentLength) {
+                remainingSegmentLength -= len;
+                x1 = coordinates[j++];
+                y1 = coordinates[j++];
+                dx = x1 - x0;
+                dy = y1 - y0;
+                len = Math.sqrt(dx * dx + dy * dy);
+                continue;
+            }
+            double dx_scaled = remainingSegmentLength * dx / len;
+            double dy_scaled = remainingSegmentLength * dy / len;
+            x0 += dx_scaled;
+            y0 += dy_scaled;
+            interpolated[i++] = x0;
+            interpolated[i++] = y0;
+            remainingSegmentLength = segmentLength;
+        }
+
+        // Last point
+        interpolated[interpolated.length - 2] = coordinates[coordinates.length - 2];
+        interpolated[interpolated.length - 1] = coordinates[coordinates.length - 1];
+
+        return interpolated;
+    }
+
+    /**
+     * Determine grid tile size to use for this request
+     *
+     * Logic here is to avoid creating large requests when the
+     * envelope is large, in that case we move from range requests
+     * to single point requests.
+     *
+     * When the envelope is small enough the overhead of
+     * unnecessary altitude values within the tiles
+     * is less than the overhead of making more service requests
+     *
+     * If the width or the height of the bounding envelope is over
+     * - 50k meters use use single data point requests
+     * - 25k meters use  64x64  tiles
+     * - 10k meters use 128x128 tiles
+     * - default to 256x256 tiles
+     *
+     * TODO: This method and the logic behind it can be further improved
+     * - Current method ignores the number of coordinates
+     * - For envelopes with small width and large height (or vice versa)
+     *     larger grid tile sizes could be beneficial (compared to 1 for example)
+     *     if there's a lot of coordinates (if not then probably not)
+     */
+    private int getGridTileSize(double[] coordinates) {
+        double[] envelope = GeomUtil.getEnvelope(coordinates);
+        double w = envelope[2] - envelope[0];
+        double h = envelope[3] - envelope[1];
+        if (w > 50000 || h > 50000) {
+            return 1;
+        }
+        if (w > 25000 || h > 25000) {
+            return 64;
+        }
+        if (w > 10000 || h > 10000) {
+            return 128;
+        }
+        return 256;
+    }
+
+    private List<DataPoint> createDataPoints(double[] coordinates, int gridTileSize) {
+        double e0 = coordinates[0];
+        double n0 = coordinates[1];
+        double distFromStart = 0.0;
+
+        List<DataPoint> points = new ArrayList<>(coordinates.length / 2);
+        for (int i = 0; i < coordinates.length;) {
+            double e1 = coordinates[i++];
+            double n1 = coordinates[i++];
+            distFromStart += GeomUtil.getDistance(e1, n1, e0, n0);
+
+            DataPoint dp = new DataPoint();
+            dp.setE(e1);
+            dp.setN(n1);
+            dp.setDistFromStart(distFromStart);
+
+            int gridX = (int) ((e1 - originEast) / offsetVectorX);
+            int gridY = (int) ((n1 - originNorth) / offsetVectorY);
+            if (gridTileSize == 1) {
+                dp.setGridTileX(gridX);
+                dp.setGridTileY(gridY);
+                dp.setGridTileOffset(0);
+            } else {
+                int gridTileX = gridX / gridTileSize;
+                int gridTileY = gridY / gridTileSize;
+                int gridTileOffsetX = gridX % gridTileSize;
+                int gridTileOffsetY = gridY % gridTileSize;
+                int gridTileOffset = gridTileOffsetY * gridTileSize + gridTileOffsetX;
+                dp.setGridTileX(gridTileX);
+                dp.setGridTileY(gridTileY);
+                dp.setGridTileOffset(gridTileOffset);
+            }
+            points.add(dp);
+            e0 = e1;
+            n0 = n1;
+        }
+        return points;
+    }
+
+    private float[] getGrid(int gridTileSize, int gridTileX, int gridTileY)
+            throws ServiceException {
+        double e0 = gridTileX * offsetVectorX * gridTileSize + originEast;
+        double n1 = gridTileY * offsetVectorY * gridTileSize + originNorth;
+
+        GetCoverage getCoverage = new GetCoverage(caps, desc, FORMAT_TIFF);
+        if (gridTileSize == 1) {
+            getCoverage.subset("E", e0);
+            getCoverage.subset("N", n1);
+        } else {
+            getCoverage.subset("E", e0, e0 + offsetVectorX * gridTileSize);
+            getCoverage.subset("N", n1 + offsetVectorY * gridTileSize, n1);
+        }
+        Map<String, String[]> getCoverageKVP = getCoverage.toKVP();
+
         String queryString = IOHelper.getParamsMultiValue(getCoverageKVP);
         String request = endPoint + "?" + queryString;
         byte[] response;
@@ -103,190 +289,19 @@ public class TerrainProfileService {
         }
 
         try {
-            final TIFFReader tiff = new TIFFReader(ByteBuffer.wrap(response));
-            final int ifdIdx = 0; // First image in TIFF file
-            final IFD ifd = tiff.getIFD(ifdIdx);
-            final int w = ifd.getWidth();
-            final int h = ifd.getHeight();
-            final int tw = ifd.getTileWidth();
-            final int th = ifd.getTileHeight();
-            final int tilesAcross = (w + tw - 1) / tw;
-            final int tilesDown = (h + th - 1) / th;
-            final int tileCount = tilesAcross * tilesDown;
-
-            final float[][] tileCache = new float[tileCount][];
-
-            List<DataPoint> points = createDataPoints(coordinates, numPoints,
-                    envelope[0], envelope[3],
-                    tw, th, tilesAcross);
-            points.sort(new Comparator<DataPoint>() {
-                @Override
-                public int compare(DataPoint o1, DataPoint o2) {
-                    int d = o1.getTileIdx() - o2.getTileIdx();
-                    return d != 0 ? d : o1.getOffsetInTile() - o2.getOffsetInTile();
-                }
-            });
-
-            for (DataPoint point : points) {
-                int tileIdx = point.getTileIdx();
-                float[] tile = tileCache[tileIdx];
-                if (tile == null) {
-                    // Only "read" the tiles we need
-                    tile = new float[tw * th];
-                    tiff.readTile(ifdIdx, tileIdx, tile);
-                    tileCache[tileIdx] = tile;
-                }
-                float altitude = tileCache[tileIdx][point.getOffsetInTile()];
-                point.setAltitude(altitude);
+            TIFFReader tiff = new TIFFReader(ByteBuffer.wrap(response));
+            IFD ifd = tiff.getIFD(0);
+            boolean tiled = ifd.getTileOffsets() != null;
+            float[] data = new float[gridTileSize * gridTileSize];
+            if (tiled) {
+                tiff.readTile(0, 0, data);
+            } else {
+                tiff.readStrip(0, 0, data);
             }
-
-            points.sort(new Comparator<DataPoint>() {
-                @Override
-                public int compare(DataPoint o1, DataPoint o2) {
-                    return Double.compare(o1.getDistFromStart(), o2.getDistFromStart());
-                }
-            });
-            return points;
+            return data;
         } catch (IllegalArgumentException e) {
             throw new ServiceException("Unexpected TIFF file", e);
         }
-    }
-
-    private List<DataPoint> createDataPoints(double[] coordinates, int numDataPoints,
-            double eastMin, double northMax,
-            int tileWidth, int tileHeight, int tilesAcross) {
-        int numCoordinates = coordinates.length / 2;
-        if (numCoordinates < numDataPoints) {
-            return createDataPointsInterpolate(coordinates, numDataPoints,
-                    eastMin, northMax, tileWidth, tileHeight, tilesAcross);
-        }
-        return createDataPointsFromCoordinates(coordinates,
-                eastMin, northMax, tileWidth, tileHeight, tilesAcross);
-    }
-
-    private List<DataPoint> createDataPointsFromCoordinates(double[] coordinates,
-            double eastMin, double northMax,
-            int tileWidth, int tileHeight, int tilesAcross) {
-        List<DataPoint> points = new ArrayList<>();
-
-        double e1 = coordinates[0];
-        double n1 = coordinates[1];
-        double distanceFromStart = 0.0;
-
-        int x = (int) Math.round((e1 - eastMin) / STEP);
-        int y = (int) Math.round((northMax - n1) / STEP);
-        int tileCol = x / tileWidth;
-        int tileRow = y / tileHeight;
-        int tileIdx = tileRow * tilesAcross + tileCol;
-        int tileOffsetX = x % tileWidth;
-        int tileOffsetY = y % tileHeight;
-        int offsetInTile = tileOffsetY * tileWidth + tileOffsetX;
-        points.add(getDataPoint(e1, n1, distanceFromStart, tileIdx, offsetInTile));
-
-        for (int i = 2; i < coordinates.length; i += 2) {
-            double e2 = coordinates[i];
-            double n2 = coordinates[i + 1];
-            distanceFromStart += GeomUtil.getDistance(e1, n1, e2, n2);
-            x = (int) Math.round((e2 - eastMin) / STEP);
-            y = (int) Math.round((northMax - n2) / STEP);
-            tileCol = x / tileWidth;
-            tileRow = y / tileHeight;
-            tileIdx = tileRow * tilesAcross + tileCol;
-            tileOffsetX = x % tileWidth;
-            tileOffsetY = y % tileHeight;
-            offsetInTile = tileOffsetY * tileWidth + tileOffsetX;
-            points.add(getDataPoint(e2, n2, distanceFromStart, tileIdx, offsetInTile));
-            e1 = e2;
-            n1 = n2;
-        }
-
-        return points;
-    }
-
-    private List<DataPoint> createDataPointsInterpolate(double[] coordinates, int numDataPoints,
-            double eastMin, double northMax, int tileWidth, int tileHeight, int tilesAcross) {
-        double totalLength = GeomUtil.getLength(coordinates);
-        int numSegments = numDataPoints - 1;
-        double segmentLength = totalLength / numSegments;
-        List<DataPoint> points = new ArrayList<>(numDataPoints);
-
-        double x1 = coordinates[0];
-        double y1 = coordinates[1];
-        double distanceFromStart = 0.0;
-
-        // First point
-        int px_x = (int) Math.round((x1 - eastMin) / STEP);
-        int px_y = (int) Math.round((northMax - y1) / STEP);
-        int tileCol = px_x / tileWidth;
-        int tileRow = px_y / tileHeight;
-        int tileIdx = tileRow * tilesAcross + tileCol;
-        int tileOffsetX = px_x % tileWidth;
-        int tileOffsetY = px_y % tileHeight;
-        int offsetInTile = tileOffsetY * tileWidth + tileOffsetX;
-        points.add(getDataPoint(x1, y1, distanceFromStart, tileIdx, offsetInTile));
-
-        // Points 1...n-1
-        double remainingSegmentLength = segmentLength;
-        int i = 2;
-        while (points.size() < (numDataPoints - 1)) {
-            double x2 = coordinates[i];
-            double y2 = coordinates[i + 1];
-            double dx = x2 - x1;
-            double dy = y2 - y1;
-            double len = Math.sqrt(dx * dx + dy * dy);
-            if (len < remainingSegmentLength) {
-                remainingSegmentLength -= len;
-                i += 2;
-                continue;
-            }
-
-            double dx_unit = dx / len;
-            double dy_unit = dy / len;
-            double dx_scaled = remainingSegmentLength * dx_unit;
-            double dy_scaled = remainingSegmentLength * dy_unit;
-            double x3 = x1 + dx_scaled;
-            double y3 = y1 + dy_scaled;
-
-            distanceFromStart += segmentLength;
-            px_x = (int) Math.round((x3 - eastMin) / STEP);
-            px_y = (int) Math.round((northMax - y3) / STEP);
-            tileCol = px_x / tileWidth;
-            tileRow = px_y / tileHeight;
-            tileIdx = tileRow * tilesAcross + tileCol;
-            tileOffsetX = px_x % tileWidth;
-            tileOffsetY = px_y % tileHeight;
-            offsetInTile = tileOffsetY * tileWidth + tileOffsetX;
-            points.add(getDataPoint(x3, y3, distanceFromStart, tileIdx, offsetInTile));
-
-            x1 = x3;
-            y1 = y3;
-            remainingSegmentLength = segmentLength;
-        }
-
-        // Last point
-        double x = coordinates[coordinates.length - 2];
-        double y = coordinates[coordinates.length - 1];
-        px_x = (int) Math.round((x - eastMin) / STEP);
-        px_y = (int) Math.round((northMax - y) / STEP);
-        tileCol = px_x / tileWidth;
-        tileRow = px_y / tileHeight;
-        tileIdx = tileRow * tilesAcross + tileCol;
-        tileOffsetX = px_x % tileWidth;
-        tileOffsetY = px_y % tileHeight;
-        offsetInTile = tileOffsetY * tileWidth + tileOffsetX;
-        points.add(getDataPoint(x, y, totalLength, tileIdx, offsetInTile));
-
-        return points;
-    }
-
-    private DataPoint getDataPoint(double e, double n, double distanceFromStart, int tileIdx, int offsetInTile) {
-        DataPoint dp = new DataPoint();
-        dp.setE(e);
-        dp.setN(n);
-        dp.setDistFromStart(distanceFromStart);
-        dp.setTileIdx(tileIdx);
-        dp.setOffsetInTile(offsetInTile);
-        return dp;
     }
 
 }

--- a/service-terrain-profile/src/main/java/fi/nls/paikkatietoikkuna/terrainprofile/TerrainProfileService.java
+++ b/service-terrain-profile/src/main/java/fi/nls/paikkatietoikkuna/terrainprofile/TerrainProfileService.java
@@ -155,12 +155,13 @@ public class TerrainProfileService {
     private List<DataPoint> createDataPoints(double[] coordinates, int numDataPoints,
             double eastMin, double northMax,
             int tileWidth, int tileHeight, int tilesAcross) {
-        int numberOfPoints = coordinates.length / 2;
-        if (numberOfPoints < numDataPoints) {
+        int numCoordinates = coordinates.length / 2;
+        if (numCoordinates < numDataPoints) {
             return createDataPointsInterpolate(coordinates, numDataPoints,
                     eastMin, northMax, tileWidth, tileHeight, tilesAcross);
         }
-        return createDataPointsFromCoordinates(coordinates, eastMin, northMax, tileWidth, tileHeight, tilesAcross);
+        return createDataPointsFromCoordinates(coordinates,
+                eastMin, northMax, tileWidth, tileHeight, tilesAcross);
     }
 
     private List<DataPoint> createDataPointsFromCoordinates(double[] coordinates,
@@ -213,6 +214,7 @@ public class TerrainProfileService {
         double y1 = coordinates[1];
         double distanceFromStart = 0.0;
 
+        // First point
         int px_x = (int) Math.round((x1 - eastMin) / STEP);
         int px_y = (int) Math.round((northMax - y1) / STEP);
         int tileCol = px_x / tileWidth;
@@ -223,6 +225,7 @@ public class TerrainProfileService {
         int offsetInTile = tileOffsetY * tileWidth + tileOffsetX;
         points.add(getDataPoint(x1, y1, distanceFromStart, tileIdx, offsetInTile));
 
+        // Points 1...n-1
         double remainingSegmentLength = segmentLength;
         int i = 2;
         while (points.size() < (numDataPoints - 1)) {
@@ -259,6 +262,8 @@ public class TerrainProfileService {
             y1 = y3;
             remainingSegmentLength = segmentLength;
         }
+
+        // Last point
         double x = coordinates[coordinates.length - 2];
         double y = coordinates[coordinates.length - 1];
         px_x = (int) Math.round((x - eastMin) / STEP);

--- a/service-terrain-profile/src/test/java/fi/nls/paikkatietoikkuna/terrainprofile/TerrainProfileHandlerTest.java
+++ b/service-terrain-profile/src/test/java/fi/nls/paikkatietoikkuna/terrainprofile/TerrainProfileHandlerTest.java
@@ -1,6 +1,7 @@
 package fi.nls.paikkatietoikkuna.terrainprofile;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -104,6 +105,51 @@ public class TerrainProfileHandlerTest {
             fail();
         } catch (ActionParamsException e) {
             assertEquals("Invalid input - expected LineString geometry", e.getMessage());
+        }
+    }
+
+    @Test
+    public void whenLineHasOnePointThrowsActionParamsException() throws JsonProcessingException, ActionException {
+        Feature feature = new Feature();
+        LineString ls = new LineString();
+        ls.add(new LngLatAlt(0, 0));
+        feature.setGeometry(ls);
+        String routeStr = om.writeValueAsString(feature);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter(TerrainProfileHandler.PARAM_ROUTE)).thenReturn(routeStr);
+        ActionParameters params = new ActionParameters();
+        params.setRequest(request);
+
+        try {
+            handler.handleAction(params);
+            fail();
+        } catch (ActionParamsException e) {
+            assertEquals("Invalid input - expected LineString with atleast two coordinates", e.getMessage());
+        }
+    }
+
+    @Test
+    public void whenLineHasTooManyPointsThrowsActionParamsException() throws JsonProcessingException, ActionException {
+        Feature feature = new Feature();
+        LineString ls = new LineString();
+        for (int i = 0; i < 10000; i++) {
+            ls.add(new LngLatAlt(i, i));
+        }
+        feature.setGeometry(ls);
+        String routeStr = om.writeValueAsString(feature);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getParameter(TerrainProfileHandler.PARAM_ROUTE)).thenReturn(routeStr);
+        ActionParameters params = new ActionParameters();
+        params.setRequest(request);
+
+        try {
+            handler.handleAction(params);
+            fail();
+        } catch (ActionParamsException e) {
+            assertTrue(e.getMessage().startsWith("Invalid input"
+                    + " - too many coordinates, maximum is"));
         }
     }
 

--- a/service-terrain-profile/src/test/java/fi/nls/paikkatietoikkuna/terrainprofile/TerrainProfileServiceTest.java
+++ b/service-terrain-profile/src/test/java/fi/nls/paikkatietoikkuna/terrainprofile/TerrainProfileServiceTest.java
@@ -1,0 +1,41 @@
+package fi.nls.paikkatietoikkuna.terrainprofile;
+
+import static org.junit.Assert.assertEquals;
+
+import fi.nls.oskari.control.ActionException;
+import fi.nls.oskari.service.ServiceException;
+import java.io.IOException;
+import java.util.List;
+import javax.xml.parsers.ParserConfigurationException;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+public class TerrainProfileServiceTest {
+
+    @Test
+    @Ignore("Depends on an outside API")
+    public void offsetIsCorrect() throws IOException, ActionException, ParserConfigurationException, SAXException, ServiceException {
+        String endPoint = "http://avoindata.maanmittauslaitos.fi/geoserver/wcs";
+        String coverageId = "korkeusmalli_10m__korkeusmalli_10m";
+        TerrainProfileService tps = new TerrainProfileService(endPoint, coverageId);
+        double[] coordinates = new double[] {
+                500002, 6822001,
+                501003, 6821004,
+                502006, 6823007,
+                501003, 6822509,
+                500502, 6823206
+        };
+
+        List<DataPoint> points = tps.getTerrainProfile(coordinates, 0);
+        for (DataPoint p : points) {
+            double e = p.getE();
+            double n = p.getN();
+            DataPoint single = tps.getTerrainProfile(new double[] { e, n }, 0).get(0);
+            assertEquals(e, single.getE(), 0.0);
+            assertEquals(n, single.getN(), 0.0);
+            assertEquals(p.getAltitude(), single.getAltitude(), 0.0);
+        }
+    }
+
+}


### PR DESCRIPTION
Current implementation creates a single WCS request, which is most of the time unnecessarily large and un-useful, new solution creates multiple WCS requests based on the grid matrix of the coverage.
Refactor DataPoint class to reflect the changes made in the logic as stated in the previous sentences.
Remove default value for numPoints - keep it as an opt-in option instead of opt-out.
Separate interpolation of points to an optional pre-step, code is now easier to read and maintain.
Add validation logic, LineStrings with less than 2 coordinates or more than 1000 coordinates will be discarded as invalid.
Move away from magical STEP, base the logic on the metadata which is read from the DescribeCoverage response.