### PR TITLE
Coordinate transformation file handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <jsoup.version>1.7.2</jsoup.version>
         <servlet.version>2.5</servlet.version>
         <geojson-jackson.version>1.8</geojson-jackson.version>
+        <commons-fileupload.version>1.3.2</commons-fileupload.version>
     </properties>
 
     <repositories>

--- a/service-coordtransform/pom.xml
+++ b/service-coordtransform/pom.xml
@@ -26,6 +26,11 @@
             <version>${jackson2.version}</version>
         </dependency>
         <dependency>
+            <groupId>commons-fileupload</groupId>
+            <artifactId>commons-fileupload</artifactId>
+            <version>${commons-fileupload.version}</version>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
             <version>${servlet.version}</version>

--- a/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordTransFile.java
+++ b/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordTransFile.java
@@ -1,0 +1,130 @@
+package fi.nls.paikkatietoikkuna.coordtransform;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CoordTransFile {
+    private String fileName;
+    private String unit;
+    private String lineSeparator;
+    private String coordinateSeparator;
+    private int headerLineCount;
+    private int decimalCount;
+    private char decimalSeparator;   
+    private boolean axisFlip;
+    private boolean prefixId;
+    private boolean writeHeader;
+    private boolean writeLineEndings;
+    private boolean writeCardinals;
+
+    private List <String> headerRows = new ArrayList<String>();
+    private List <String> ids = new ArrayList<String>();
+    private List <String> lineEnds = new ArrayList<String>();
+
+    public String getFileName() {
+        return fileName;
+    }
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+    public int getHeaderLineCount() {
+        return headerLineCount;
+    }
+    public void setHeaderLineCount(int headerLineCount) {
+        this.headerLineCount = headerLineCount;
+    }
+    public boolean isAxisFlip() {
+        return axisFlip;
+    }
+    public void setAxisFlip(boolean axisFlip) {
+        this.axisFlip = axisFlip;
+    }
+    public boolean isPrefixId() {
+        return prefixId;
+    }
+    public void setPrefixId(boolean prefixId) {
+        this.prefixId = prefixId;
+    }
+    public char getDecimalSeparator() {
+        return decimalSeparator;
+    }
+    public void setDecimalSeparator(char decimalSeparator) {
+        this.decimalSeparator = decimalSeparator;
+    }
+    public String getUnit() {
+        return unit;
+    }
+    public void setUnit(String unit) {
+        this.unit = unit;
+    }
+    public List<String> getHeaderRows() {
+        return headerRows;
+    }
+    public void setHeaderRows(List<String> headerRows) {
+        this.headerRows = headerRows;
+    }
+    public void addHeaderRow (String row){
+        this.headerRows.add(row);
+    }
+    public List <String> getIds() {
+        return ids;
+    }
+    public void setIds(List <String> ids) {
+        this.ids = ids;
+    }
+    public void addId (String id){
+        this.ids.add(id);
+    }
+    public String getLineSeparator() {
+        return lineSeparator;
+    }
+    public void setLineSeparator(String lineSeparator) {
+        this.lineSeparator = lineSeparator;
+    }
+    public String getCoordinateSeparator() {
+        return coordinateSeparator;
+    }
+    public void setCoordinateSeparator(String coordinateSeparator) {
+        this.coordinateSeparator = coordinateSeparator;
+    }
+    public boolean isWriteHeader() {
+        return writeHeader;
+    }
+    public void setWriteHeader(boolean writeHeader) {
+        this.writeHeader = writeHeader;
+    }
+    public boolean isWriteLineEndings() {
+        return writeLineEndings;
+    }
+    public void setWriteLineEndings(boolean writeLineEndings) {
+        this.writeLineEndings = writeLineEndings;
+    }
+    public List <String> getLineEnds() {
+        return lineEnds;
+    }
+    public void setLineEnds(List <String> lineEnds) {
+        this.lineEnds = lineEnds;
+    }
+    public void addLineEnd (String lineEnd){
+        this.lineEnds.add(lineEnd);
+    }
+    public boolean isWriteCardinals() {
+        return writeCardinals;
+    }
+    public void setWriteCardinals(boolean writeCardinals) {
+        this.writeCardinals = writeCardinals;
+    }
+    public int getDecimalCount() {
+        return decimalCount;
+    }
+    public void setDecimalCount(int decimalCount) {
+        this.decimalCount = decimalCount;
+    }
+    public void copyArrays (CoordTransFile from){
+        headerRows = from.getHeaderRows();
+        ids = from.getIds();
+        lineEnds = from.getLineEnds();
+    }
+}
+    
+    

--- a/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordTransFile.java
+++ b/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordTransFile.java
@@ -17,6 +17,7 @@ public class CoordTransFile {
     private boolean writeLineEndings;
     private boolean writeCardinals;
 
+    private boolean hasMoreCoordinates = false;
     private List <String> headerRows = new ArrayList<String>();
     private List <String> ids = new ArrayList<String>();
     private List <String> lineEnds = new ArrayList<String>();
@@ -124,6 +125,12 @@ public class CoordTransFile {
         headerRows = from.getHeaderRows();
         ids = from.getIds();
         lineEnds = from.getLineEnds();
+    }
+    public boolean isHasMoreCoordinates() {
+        return hasMoreCoordinates;
+    }
+    public void setHasMoreCoordinates(boolean hasMoreCoordinates) {
+        this.hasMoreCoordinates = hasMoreCoordinates;
     }
 }
     

--- a/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordTransService.java
+++ b/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordTransService.java
@@ -117,13 +117,11 @@ public class CoordTransService {
                 value =  value.multiply(DEC_TO_GRAD, DECIMAL_PRECISION).setScale(decimals,RoundingMode.HALF_UP);
                 return value.toPlainString();
             case "DD":
-                System.out.println ("DD" + getFormatedValue(value, decimals));
                 return getFormatedValue(value, decimals); //DD.dd
             case "DD MM":
                 separator = " ";
             case "DDMM":
                 result = getPrefixedIntPart (value); //DD
-                System.out.println ("DDMM" + result);
                 fractPart = value.remainder(BigDecimal.ONE);
                 value = fractPart.multiply(HOUR_TO_MIN, DECIMAL_PRECISION);
                 return result + separator + getFormatedValue(value, decimals);// add MM.mm

--- a/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordTransService.java
+++ b/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordTransService.java
@@ -1,6 +1,12 @@
 package fi.nls.paikkatietoikkuna.coordtransform;
 
 import com.vividsolutions.jts.geom.Coordinate;
+
+import fi.nls.oskari.control.ActionException;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -11,6 +17,14 @@ public class CoordTransService {
 
     private static final String SEP_COORD = ";";
     private static final String SEP_COORD_PART = ",";
+    private static final String GRADIAN = "gradian";
+    private static final String RADIAN = "radian";
+    private static final MathContext DECIMAL_PRECISION = MathContext.DECIMAL128; //DECIMAL64 -> 16 decimals, DECIMAL128 -> 34 decimals
+    private static final BigDecimal HOUR_TO_MIN = new BigDecimal(60);
+    private static final BigDecimal HOUR_TO_SEC = new BigDecimal(3600);
+    private static final BigDecimal PI2 = new BigDecimal("6.283185307179586476925286766559"); //2*pi
+    private static final BigDecimal DEC_TO_GRAD = BigDecimal.TEN.divide(new BigDecimal(9), DECIMAL_PRECISION);
+    private static final BigDecimal DEC_TO_RAD = PI2.divide(new BigDecimal(360), DECIMAL_PRECISION);
 
     public static String createQuery(String sourceCrs, String targetCrs,
             final List<Coordinate> coords, final int dimension) {
@@ -49,5 +63,110 @@ public class CoordTransService {
             }
         }
     }
+    public static double transformUnitToDegree (String coord, String unit) throws ActionException{
+        coord = coord.trim();
+        BigDecimal value;
+        if (GRADIAN.equals(unit)){
+            value = new BigDecimal(coord);
+            value = value.divide(DEC_TO_GRAD, DECIMAL_PRECISION);
+            return value.doubleValue();
+        }else if (RADIAN.equals(unit)){
+            value = new BigDecimal(coord);
+            value = value.divide(DEC_TO_RAD, DECIMAL_PRECISION);
+            return value.doubleValue();
+        }
 
+        BigDecimal dd = new BigDecimal(coord.substring(0, 2));
+        BigDecimal mm;
+        BigDecimal ss;
+        switch (unit) {
+            case "DDMM":
+                mm =  new BigDecimal(coord.substring(2));
+                dd = dd.add(mm.divide(HOUR_TO_MIN, DECIMAL_PRECISION));
+                return dd.doubleValue();
+            case "DD MM":
+                mm =  new BigDecimal(coord.substring(3));
+                dd = dd.add(mm.divide(HOUR_TO_MIN, DECIMAL_PRECISION));
+                return dd.doubleValue();
+            case "DDMMSS":
+                mm =  new BigDecimal(coord.substring(2, 4));
+                ss =  new BigDecimal(coord.substring(4));
+                dd = dd.add(mm.divide(HOUR_TO_MIN, DECIMAL_PRECISION));
+                dd = dd.add(ss.divide(HOUR_TO_SEC, DECIMAL_PRECISION));
+                return dd.doubleValue();
+            case "DD MM SS":
+                mm =  new BigDecimal(coord.substring(3, 5));
+                ss =  new BigDecimal(coord.substring(6));
+                dd = dd.add(mm.divide(HOUR_TO_MIN, DECIMAL_PRECISION));
+                dd = dd.add(ss.divide(HOUR_TO_SEC, DECIMAL_PRECISION));
+                return dd.doubleValue();
+            default:
+                throw new ActionException("Invalid unit");
+        }
+    }
+    public static String transformDegreeToUnit (double coord, String unit, int decimals) throws ActionException{
+        BigDecimal value = new BigDecimal(coord, DECIMAL_PRECISION);
+        BigDecimal fractPart;
+        String separator = "";
+        String result;
+        switch (unit) {
+            case RADIAN:
+                value =  value.multiply(DEC_TO_RAD, DECIMAL_PRECISION).setScale(decimals,RoundingMode.HALF_UP);
+                return value.toPlainString();
+            case GRADIAN:
+                value =  value.multiply(DEC_TO_GRAD, DECIMAL_PRECISION).setScale(decimals,RoundingMode.HALF_UP);
+                return value.toPlainString();
+            case "DD":
+                System.out.println ("DD" + getFormatedValue(value, decimals));
+                return getFormatedValue(value, decimals); //DD.dd
+            case "DD MM":
+                separator = " ";
+            case "DDMM":
+                result = getPrefixedIntPart (value); //DD
+                System.out.println ("DDMM" + result);
+                fractPart = value.remainder(BigDecimal.ONE);
+                value = fractPart.multiply(HOUR_TO_MIN, DECIMAL_PRECISION);
+                return result + separator + getFormatedValue(value, decimals);// add MM.mm
+            case "DD MM SS":
+                separator = " ";
+            case "DDMMSS":
+                result = getPrefixedIntPart (value); //DD
+                fractPart = value.remainder(BigDecimal.ONE);
+                value = fractPart.multiply(HOUR_TO_MIN, DECIMAL_PRECISION);
+                result += separator + getPrefixedIntPart (value); //add MM
+                fractPart = value.remainder(BigDecimal.ONE);
+                value = fractPart.multiply(HOUR_TO_MIN, DECIMAL_PRECISION);
+                return result + separator + getFormatedValue(value, decimals); //add SS.ss
+            default:
+                throw new ActionException("Invalid unit");
+        }
+    }
+    public static String round(double value, int decimals) {
+        BigDecimal bd = new BigDecimal(value);
+        bd = bd.setScale(decimals, RoundingMode.HALF_UP);
+        return bd.toPlainString();
+    }
+    //Min and sec values cannot be negative so we can use this for formating them also
+    private static String getFormatedValue (BigDecimal value, int decimals){
+        value = value.setScale(decimals, RoundingMode.HALF_UP);
+        // 10 > value < -10
+        if (value.compareTo(BigDecimal.TEN)>= 0 || value.compareTo(BigDecimal.TEN.negate()) <= 0){
+            return value.toPlainString();
+        //value -9 - 0
+        } else if (value.compareTo(BigDecimal.ZERO) == -1){
+            return "-0" + value.negate().toPlainString();
+        }
+        //value 0 - 9
+        return "0" + value.toPlainString();
+    }
+    private static String getPrefixedIntPart (BigDecimal value){
+        int intPart = value.intValue();
+        if (intPart >=10 || intPart <= -10){
+            return Integer.toString(intPart);
+        }
+        else if (intPart < 0 ){
+            return "-0" + intPart * -1;
+        }
+        return "0" + intPart;
+    }
 }

--- a/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandler.java
+++ b/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandler.java
@@ -201,11 +201,13 @@ public class CoordinateTransformationActionHandler extends ActionHandler {
         }
 
         HttpServletResponse response = params.getResponse();
+        if (transformToFile){
+            String fileName = addFileExt(exportSettings.getFileName());
+            response.setContentType(FILE_TYPE);
+            response.setHeader("Content-Disposition", "attachment; filename=" + fileName);
+        }
         try (OutputStream out = response.getOutputStream()) {
             if (transformToFile){
-                String fileName = addFileExt(exportSettings.getFileName());
-                response.setContentType(FILE_TYPE);
-                response.setHeader("Content-Disposition", "attachment; filename=" + fileName);
                 writeFileResponse(out, coords, targetDimension, exportSettings, targetCrs);
             } else {
                 if (importSettings != null){
@@ -261,9 +263,7 @@ public class CoordinateTransformationActionHandler extends ActionHandler {
             transformUnit = true;
         }
         double x,y,z;
-        try{
-            BufferedReader br = new BufferedReader(
-                    new InputStreamReader(file.getInputStream()));
+        try(BufferedReader br = new BufferedReader(new InputStreamReader(file.getInputStream()))){
             //skip row and store row as header row
             for (int i = 0 ; i < headerLineCount && (line=br.readLine())!=null ;i++) {
                 sourceOptions.addHeaderRow(line);
@@ -322,7 +322,6 @@ public class CoordinateTransformationActionHandler extends ActionHandler {
                     break;
                 }
             }
-            br.close();
         } catch (UnsupportedEncodingException e){
             throw new ActionParamsException("Encoding - Invalid file");
         } catch (IOException e){
@@ -480,8 +479,7 @@ public class CoordinateTransformationActionHandler extends ActionHandler {
 
     protected void writeFileResponse(OutputStream out, List<Coordinate> coords, final int dimension, CoordTransFile opts, String crs)
         throws ActionException {
-        try {
-            BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(out));
+        try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(out))){
             String xCoord;
             String yCoord;
             String zCoord;
@@ -562,7 +560,6 @@ public class CoordinateTransformationActionHandler extends ActionHandler {
                 }
                 bw.write(lineSeparator);
             }
-            bw.close();
         } catch (IOException e) {
             throw new ActionException("Failed to write file", e);
         }

--- a/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandler.java
+++ b/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandler.java
@@ -4,37 +4,94 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vividsolutions.jts.geom.Coordinate;
 import fi.nls.oskari.annotation.OskariActionRoute;
 import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.control.ActionHandler;
 import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.control.ActionParamsException;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.util.IOHelper;
 import fi.nls.oskari.util.PropertyUtil;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload.FileUploadException;
+import org.apache.commons.fileupload.disk.DiskFileItemFactory;
+import org.apache.commons.fileupload.servlet.ServletFileUpload;
+import org.apache.commons.io.IOUtils;
+
 
 /**
  * Handles CoordinateTransformation action_route requests
  */
 @OskariActionRoute("CoordinateTransformation")
 public class CoordinateTransformationActionHandler extends ActionHandler {
+    protected static final Logger log = LogFactory.getLogger(CoordinateTransformationActionHandler.class);
 
     private static final String PROP_END_POINT = "coordtransform.endpoint";
+    private static final String PROP_MAX_FILE_SIZE_MB = "coordtransform.max.filesize.mb";
+    private static final String PROP_MAX_COORDS_TO_ARRAY = "coordtransform.max.coordinates.array";
+    private static final String PROP_MAX_COORDS_TO_QUERY = "coordtransform.max.coordinates.query";
+    private static final String PROP_COORDS_TO_PREVIEW = "coordtransform.preview.size";
 
     protected static final String PARAM_SOURCE_CRS = "sourceCrs";
     protected static final String PARAM_SOURCE_H_CRS = "sourceHeightCrs";
     protected static final String PARAM_TARGET_CRS = "targetCrs";
     protected static final String PARAM_TARGET_H_CRS = "targetHeightCrs";
+    protected static final String PARAM_TRANSFORM_TYPE = "transformType";
+    protected static final String PARAM_SOURCE_DIMENSION = "sourceDimension";
+    protected static final String PARAM_TARGET_DIMENSION = "targetDimension";
+    protected static final String KEY_IMPORT_SETTINGS = "importSettings";
+    protected static final String KEY_EXPORT_SETTINGS = "exportSettings";
+
+    protected static final String RESPONSE_COORDINATES = "coordinates";
+    protected static final String RESPONSE_INPUT_COORDINATES = "inputCoordinates";
+    protected static final String RESPONSE_DIMENSION = "dimension";
+
+    protected static final String[] DEGREES_TO_FORMAT = new String [] {"DD MM SS", "DD MM", "DDMMSS", "DDMM"};
+    protected static final String DEGREE = "degree";
+    protected static final String FILE_EXT = "txt";
+    protected static final String FILE_TYPE = "text/plain";
+
+    protected final Map <String, String> lineSeparators = new HashMap<String, String>();
+    protected final Map <String, String> coordinateSeparators = new HashMap<String, String>();
 
     private JsonFactory jf;
     private String endPoint;
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private boolean hasMoreCoordinates;
+    private static final int MB = 1024 * 1024;
+    private final int maxFileSize = PropertyUtil.getOptional(PROP_MAX_FILE_SIZE_MB, 50) * MB;
+    private final int maxCoordsToArray = PropertyUtil.getOptional(PROP_MAX_COORDS_TO_ARRAY, 100);
+    private final int coordsToPreview = PropertyUtil.getOptional(PROP_COORDS_TO_PREVIEW, 10);
+    private final int maxCoordsToQuery = PropertyUtil.getOptional(PROP_MAX_COORDS_TO_QUERY, 500);
+
+    // Store files smaller than 128kb in memory instead of writing them to disk
+    private static final int MAX_SIZE_MEMORY = 128 * 1024;
+    private final DiskFileItemFactory diskFileItemFactory = new DiskFileItemFactory(MAX_SIZE_MEMORY, null);
 
     public CoordinateTransformationActionHandler() {
         this(null);
@@ -50,30 +107,87 @@ public class CoordinateTransformationActionHandler extends ActionHandler {
         if (endPoint == null) {
             endPoint = PropertyUtil.getNecessary(PROP_END_POINT);
         }
+        lineSeparators.put("win","\r\n");
+        lineSeparators.put("mac","\n");
+        lineSeparators.put("unix","\r");
+
+        coordinateSeparators.put("space", " ");
+        coordinateSeparators.put("tab", "\t");
+        coordinateSeparators.put("comma", ",");
     }
 
     @Override
     public void handleAction(ActionParameters params) throws ActionException {
+        hasMoreCoordinates = false;
         String sourceCrs = getSourceCrs(params);
         String targetCrs = getTargetCrs(params);
-        int dimension = sourceCrs.indexOf(',') > 0 ? 3 : 2;
-
+        String transformType = params.getHttpParam(PARAM_TRANSFORM_TYPE);
+        int sourceDimension = params.getRequiredParamInt(PARAM_SOURCE_DIMENSION);
+        int targetDimension = params.getRequiredParamInt(PARAM_TARGET_DIMENSION);
+        boolean transformToFile = false;
+        int queryDimension = sourceDimension;
+        boolean addZeroes = false;
+        if (sourceDimension == 2 && targetDimension == 3){
+            addZeroes = true;
+            queryDimension = 3; //parse added zeroes to query
+            sourceCrs = sourceCrs + ",EPSG:3900"; //add N2000 that coordtrans service doesn't fail
+        }
         List<Coordinate> coords;
-        try (InputStream in = params.getRequest().getInputStream()) {
-            coords = parseInputCoordinates(in, dimension);
-        } catch (IOException e) {
-            throw new ActionException("Failed to parse input JSON!");
+        List<Coordinate> inputCoords = null;
+
+        List<FileItem> fileItems;
+        Map<String, String> formParams;
+        CoordTransFile importSettings;
+        CoordTransFile exportSettings = null;
+        FileItem file;
+        //TODO: is there better way to get transformation type??
+        switch(transformType){
+            case "A2A":
+                coords = getCoordsFromJsonArray (params, sourceDimension, addZeroes);
+                break;
+            case "A2F":
+                transformToFile = true;
+                try {
+                    exportSettings = mapper.readValue(params.getHttpParam(KEY_EXPORT_SETTINGS), CoordTransFile.class);
+                } catch (IOException e) {
+                    throw new ActionParamsException("Invalid export file settings", "invalid_export_settings");
+                }
+                coords = getCoordsFromJsonArray (params, sourceDimension, addZeroes);
+                break;
+            case "F2A":
+                fileItems = getFileItems(params.getRequest());
+                formParams = getFormParams(fileItems);
+                file = getFile(fileItems);
+                importSettings = getFileSettings(formParams, KEY_IMPORT_SETTINGS);
+                coords = getCoordsFromFile (importSettings, file, sourceDimension, addZeroes, false);
+                //store input coords
+                inputCoords = coords.stream().map(c -> new Coordinate (c)).collect(Collectors.toList());
+                break;
+            case "F2F":
+                transformToFile = true;
+                fileItems = getFileItems(params.getRequest());
+                formParams = getFormParams(fileItems);
+                file = getFile(fileItems);
+                importSettings = getFileSettings(formParams, KEY_IMPORT_SETTINGS);
+                exportSettings = getFileSettings(formParams, KEY_EXPORT_SETTINGS);
+                coords = getCoordsFromFile (importSettings, file, sourceDimension, addZeroes, exportSettings.isWriteLineEndings());
+                exportSettings.copyArrays(importSettings);
+                break;
+            default:
+                throw new ActionParamsException("Unknown transform type");
         }
 
-        String query = CoordTransService.createQuery(sourceCrs, targetCrs, coords, dimension);
-
+        if (coords.isEmpty()){
+            throw new ActionParamsException("No coordinates", "no_coordinates");
+        }
+        //TODO if coords.size() > maxCoordsToQuery -> post or split to multiple queries
+        String query = CoordTransService.createQuery(sourceCrs, targetCrs, coords, queryDimension);
         HttpURLConnection conn;
         try {
             conn = IOHelper.getConnection(endPoint + query);
         } catch (IOException e) {
             throw new ActionException("Failed to connect to CoordTrans service");
         }
-
         byte[] serviceResponseBytes;
         try {
             serviceResponseBytes = IOHelper.readBytes(conn);
@@ -83,20 +197,181 @@ public class CoordinateTransformationActionHandler extends ActionHandler {
 
         try {
             // Reuse the double array
-            CoordTransService.parseResponse(serviceResponseBytes, coords, dimension);
+            CoordTransService.parseResponse(serviceResponseBytes, coords, targetDimension);
         } catch (IllegalArgumentException e) {
             throw new ActionException(e.getMessage());
         }
 
         HttpServletResponse response = params.getResponse();
-        response.setContentType(IOHelper.CONTENT_TYPE_JSON);
         try (OutputStream out = response.getOutputStream()) {
-            writeJsonResponse(out, coords, dimension);
+            if (transformToFile){
+                String fileName = addFileExt(exportSettings.getFileName());
+                writeFile (coords, targetDimension, exportSettings, targetCrs);
+                response.setContentType(FILE_TYPE);
+                response.setHeader("Content-Disposition", "attachment; filename=" + fileName);
+                response.setHeader("Content-Length", String.valueOf(new File(fileName).length()));
+                FileInputStream  fis = new FileInputStream(fileName);
+                IOUtils.copy(fis,out);
+                out.flush();
+            } else {
+                response.setContentType(IOHelper.CONTENT_TYPE_JSON);
+                writeJsonResponse(out, coords, inputCoords, targetDimension);
+            }
         } catch (IOException e) {
             throw new ActionException("Failed to write JSON to client");
         }
     }
+    private List<Coordinate> getCoordsFromJsonArray (ActionParameters params, int dimension, boolean addZeroes) throws ActionException{
+        List<Coordinate> coords;
+        try (InputStream in = params.getRequest().getInputStream()) {
+            coords = parseInputCoordinates(in, dimension, addZeroes);
+        } catch (IOException e) {
+            throw new ActionException("Failed to parse input JSON!");
+        }
+        return coords;
+    }
 
+    protected List<Coordinate> getCoordsFromFile (CoordTransFile sourceOptions, FileItem file, int dimension, boolean addZeroes, boolean storeLineEnds) throws ActionException{
+        List<Coordinate> coordinates = new ArrayList<>();
+        String line;
+        String[] coords;
+        int xIndex = 0;
+        int yIndex = 1;
+        int zIndex = 2;
+        int coordDimension = dimension;
+        int headerLineCount = sourceOptions.getHeaderLineCount();
+        String coordSeparator = coordinateSeparators.get(sourceOptions.getCoordinateSeparator());
+        if (sourceOptions.isAxisFlip()){
+            xIndex = 1;
+            yIndex = 0;
+        }
+        if (sourceOptions.isPrefixId()){
+            xIndex++;
+            yIndex++;
+            zIndex++;
+            coordDimension++;
+        }
+        boolean replaceCommas = false;
+        if (sourceOptions.getDecimalSeparator()==','){
+            replaceCommas = true;
+        }
+        String unit = sourceOptions.getUnit();
+        boolean transformUnit = false;
+        if (unit != null && !unit.equals(DEGREE)){
+            transformUnit = true;
+        }
+        double x,y,z;
+        try{
+            BufferedReader br = new BufferedReader(
+                    new InputStreamReader(file.getInputStream()));
+            //skip row and store row as header row
+            for (int i = 0 ; i < headerLineCount && (line=br.readLine())!=null ;i++) {
+                sourceOptions.addHeaderRow(line);
+            }
+            while ((line=br.readLine())!=null) {
+                /* Now coordinate separator comes from frontend
+                //try to get coordinate separator from first coordinate line
+                if(coordSeparator==null){
+                    coordSeparator = CoordTransService.getCoordSeparator(line, dimension, sourceOptions.isPrefixId());
+                    sourceOptions.setCoordinateSeparator(coordSeparator);
+                }*/
+                //skip empty lines
+                if (line.trim().isEmpty()){
+                    continue;
+                }
+                //replace commas
+                if (replaceCommas){
+                    line = line.replace(',','.');
+                }
+                coords = line.split(coordSeparator);
+                if (transformUnit){
+                    x = CoordTransService.transformUnitToDegree (coords[xIndex], unit);
+                    y = CoordTransService.transformUnitToDegree (coords[yIndex], unit);
+                } else {
+                    x = Double.valueOf(coords[xIndex]);
+                    y = Double.valueOf(coords[yIndex]);
+                }
+                if (dimension == 3){
+                    z = Double.valueOf(coords[zIndex]);
+                    coordinates.add(new Coordinate(x, y, z));
+                }else if (addZeroes == true){
+                    coordinates.add(new Coordinate(x, y, 0));
+                } else {
+                    coordinates.add(new Coordinate(x, y));
+                }
+                if (sourceOptions.isPrefixId()){
+                    sourceOptions.addId(coords[0]);
+                }
+                if (storeLineEnds == true){
+                    String lineEnd = "";
+                    //add coordSeparator back if lineEnding string is slitted (e.g. coordSeparator is " ")
+                    for (int i = coordDimension; i < coords.length; i++){
+                        if (i == coordDimension){
+                            lineEnd += coords[i];
+                        } else {
+                            lineEnd += coordSeparator + coords[i];
+                        }
+                    }
+                    sourceOptions.addLineEnd(lineEnd);
+                }
+                if (coordinates.size() == maxCoordsToArray){ //TODO index
+                    this.hasMoreCoordinates = true;
+                    break;
+                }
+            }
+            br.close();
+        } catch (UnsupportedEncodingException e){
+            throw new ActionParamsException("Encoding - Invalid file");
+        } catch (IOException e){
+            throw new ActionParamsException("IO - Invalid file");
+        } catch (NumberFormatException e){
+            throw new ActionParamsException("Expected a number");
+        }
+        return coordinates;
+    }
+    private CoordTransFile getFileSettings (Map<String, String> formParams, String key) throws ActionParamsException{
+        try {
+            return mapper.readValue(formParams.get(key), CoordTransFile.class);
+        } catch (Exception e) {
+            throw new ActionParamsException("Invalid file settings: " + key, "invalid_file_settings");
+        }
+    }
+
+    private List<FileItem> getFileItems(HttpServletRequest request) throws ActionException {
+        try {
+            request.setCharacterEncoding("UTF-8");
+            ServletFileUpload upload = new ServletFileUpload(diskFileItemFactory);
+            upload.setSizeMax(maxFileSize);
+            return upload.parseRequest(request);
+        } catch (UnsupportedEncodingException | FileUploadException e) {
+            throw new ActionException("Failed to read request", e);
+        }
+    }
+    private Map<String, String> getFormParams(List<FileItem> fileItems) {
+        return fileItems.stream()
+                .filter(f -> f.isFormField())
+                .collect(Collectors.toMap(
+                        f -> f.getFieldName(),
+                        f -> new String(f.get(), StandardCharsets.UTF_8)));
+    }
+    private FileItem getFile (List<FileItem> fileItems) throws ActionParamsException {
+        return fileItems.stream()
+            .filter(f -> !f.isFormField())
+            .findAny() // If there are more files we'll get the file or fail miserably
+            .orElseThrow(() -> new ActionParamsException("No file entry", "no_file"));
+    }
+    //add .txt if missing
+    private String addFileExt(String name) {
+        int i = name.lastIndexOf('.');
+        if (i < 0 || i + 1 == name.length()) {
+            return name + "." + FILE_EXT;
+        }
+        if (FILE_EXT.equals(name.substring(i + 1))){
+            return name;
+        } else {
+            return name + "." + FILE_EXT;
+        }
+    }
     private String getSourceCrs(ActionParameters params) throws ActionParamsException {
         String sourceCrs = params.getRequiredParam(PARAM_SOURCE_CRS);
         String sourceHeightCrs = params.getHttpParam(PARAM_SOURCE_H_CRS);
@@ -116,11 +391,11 @@ public class CoordinateTransformationActionHandler extends ActionHandler {
     }
 
 
-    protected List<Coordinate> parseInputCoordinates(final InputStream in, final int dimension)
+    protected List<Coordinate> parseInputCoordinates(final InputStream in, final int dimension, final boolean addZeroes)
             throws IOException, ActionParamsException {
         try (JsonParser parser = jf.createParser(in)) {
             if (parser.nextToken() != JsonToken.START_ARRAY) {
-                throw new ActionParamsException("Expected input starting with an array");
+                throw new ActionParamsException("Expected input starting with an array", "invalid_coord");
             }
 
             List<Coordinate> coordinates = new ArrayList<>(8);
@@ -128,7 +403,7 @@ public class CoordinateTransformationActionHandler extends ActionHandler {
 
             while ((token = parser.nextToken()) != JsonToken.END_ARRAY) {
                 if (token != JsonToken.START_ARRAY) {
-                    throw new ActionParamsException("Expected array opening");
+                    throw new ActionParamsException("Expected array opening", "invalid_coord");
                 }
 
                 assertNumber(parser.nextToken(), "Expected a number");
@@ -136,7 +411,11 @@ public class CoordinateTransformationActionHandler extends ActionHandler {
                 assertNumber(parser.nextToken(), "Expected a number");
                 double y = parser.getDoubleValue();
                 if (dimension == 2) {
-                    coordinates.add(new Coordinate(x, y));
+                    if (addZeroes == true){
+                        coordinates.add(new Coordinate(x, y, 0));
+                    }else{
+                        coordinates.add(new Coordinate(x, y));
+                    }
                 } else {
                     assertNumber(parser.nextToken(), "Expected a number");
                     double z = parser.getDoubleValue();
@@ -144,7 +423,7 @@ public class CoordinateTransformationActionHandler extends ActionHandler {
                 }
 
                 if (parser.nextToken() != JsonToken.END_ARRAY) {
-                    throw new ActionParamsException("Expected array closing");
+                    throw new ActionParamsException("Expected array closing", "invalid_coord");
                 }
             }
 
@@ -154,16 +433,17 @@ public class CoordinateTransformationActionHandler extends ActionHandler {
 
     private void assertNumber(JsonToken token, String err) throws ActionParamsException {
         if (token != JsonToken.VALUE_NUMBER_FLOAT && token != JsonToken.VALUE_NUMBER_INT) {
-            throw new ActionParamsException(err);
+            throw new ActionParamsException(err, "invalid_number");
         }
     }
 
-    protected void writeJsonResponse(OutputStream out, List<Coordinate> coords, final int dimension)
+    protected void writeJsonResponse(OutputStream out, List<Coordinate> coords, List<Coordinate> inputCoords, final int dimension)
             throws ActionException {
         try (JsonGenerator json = jf.createGenerator(out)) {
             json.writeStartObject();
-            json.writeNumberField("dimension", dimension);
-            json.writeFieldName("coordinates");
+            json.writeNumberField(RESPONSE_DIMENSION, dimension);
+            json.writeBooleanField("hasMoreCoordinates", this.hasMoreCoordinates);
+            json.writeFieldName(RESPONSE_COORDINATES);
             json.writeStartArray();
             for (Coordinate coord : coords) {
                 json.writeStartArray();
@@ -175,10 +455,122 @@ public class CoordinateTransformationActionHandler extends ActionHandler {
                 json.writeEndArray();
             }
             json.writeEndArray();
+            if (inputCoords != null){
+                json.writeFieldName(RESPONSE_INPUT_COORDINATES);
+                json.writeStartArray();
+                for (Coordinate coord : inputCoords) {
+                    json.writeStartArray();
+                    json.writeNumber(coord.x);
+                    json.writeNumber(coord.y);
+                    if (dimension == 3) {
+                        json.writeNumber(coord.z);
+                    }
+                    json.writeEndArray();
+                }
+                json.writeEndArray();
+            }
             json.writeEndObject();
         } catch (IOException e) {
             throw new ActionException("Failed to write JSON");
         }
     }
 
+    protected void writeFile(List<Coordinate> coords, final int dimension, CoordTransFile opts, String crs)
+        throws ActionException {
+        try {
+            String fileName = addFileExt(opts.getFileName());
+            BufferedWriter bw = new BufferedWriter(new FileWriter (fileName));
+            String xCoord;
+            String yCoord;
+            String zCoord;
+            String lineSeparator = lineSeparators.get(opts.getLineSeparator());
+            String coordSeparator = coordinateSeparators.get(opts.getCoordinateSeparator());
+            int decimals = opts.getDecimalCount();
+            boolean replaceCommas = opts.getDecimalSeparator() == ',';
+            boolean prefixId = opts.isPrefixId();
+            boolean flipAxis = opts.isAxisFlip();
+            boolean prefixWithIndex = false;
+            boolean writeCardinals = opts.isWriteCardinals();
+            List <String> ids = opts.getIds();
+            List <String> lineEndings = opts.getLineEnds();
+            boolean writeEndings = opts.isWriteLineEndings() && !lineEndings.isEmpty();
+            String unit = opts.getUnit();
+            boolean transformUnit = false;
+            if (unit != null && !unit.equals(DEGREE)){
+                transformUnit = true;
+            }
+            if (opts.isPrefixId()){
+                if(ids.isEmpty()){
+                    prefixWithIndex = true;
+                }
+            }
+            // TODO: should we add only: Coordinate Reference System: KKJ
+            // if we want localized header then frontend should send header String instead of boolean
+            if (opts.isWriteHeader()){
+                bw.write("Coordinate Reference System:" + crs);
+                bw.write(lineSeparator);
+                for (String headerRow : opts.getHeaderRows()){
+                    bw.write(headerRow);
+                    bw.write(lineSeparator);
+                }
+            }
+            for (int i = 0; i < coords.size() ; i++) {
+                Coordinate coord = coords.get(i);
+                if (transformUnit){
+                    xCoord = CoordTransService.transformDegreeToUnit(coord.x, unit, decimals);
+                    yCoord = CoordTransService.transformDegreeToUnit(coord.y, unit, decimals);
+                } else {
+                    xCoord = CoordTransService.round(coord.x, decimals);
+                    yCoord = CoordTransService.round(coord.y, decimals);
+                }
+                if (replaceCommas){
+                    xCoord = xCoord.replace('.',',');
+                    yCoord = yCoord.replace('.',',');
+                }
+                //TODO: should we use also W, S for negative coordinates
+                if (writeCardinals){
+                    xCoord += "E";
+                    yCoord += "N";
+                }
+                if (prefixId && prefixWithIndex){
+                    bw.write(i + coordSeparator);
+                } else if (prefixId){
+                    bw.write(ids.get(i) + coordSeparator);
+                }
+                if (flipAxis){
+                    bw.write(yCoord);
+                    bw.write(coordSeparator);
+                    bw.write(xCoord);
+                }else {
+                    bw.write(xCoord);
+                    bw.write(coordSeparator);
+                    bw.write(yCoord);
+                }
+                if (dimension == 3) {
+                    zCoord = CoordTransService.round(coord.z, decimals);
+                    if (replaceCommas){
+                        zCoord = zCoord.replace('.',',');
+                    }
+                    bw.write(coordSeparator);
+                    bw.write(zCoord);
+                }
+                if (writeEndings){
+                    bw.write(coordSeparator);
+                    bw.write(lineEndings.get(i));
+                }
+                bw.write(lineSeparator);
+            }
+            bw.close();
+        } catch (IOException e) {
+            throw new ActionException("Failed to write file", e);
+        }
+    }
+    //handle id, axisflip, dimension
+    protected String getOutputLine (Coordinate coord, CoordTransFile opt){
+        String line = "";
+        if (",".equals(opt.getDecimalSeparator())){
+            line = line.replace('.',',');
+        }
+        return line;
+    }
 }

--- a/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandler.java
+++ b/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandler.java
@@ -564,12 +564,4 @@ public class CoordinateTransformationActionHandler extends ActionHandler {
             throw new ActionException("Failed to write file", e);
         }
     }
-    //handle id, axisflip, dimension
-    protected String getOutputLine (Coordinate coord, CoordTransFile opt){
-        String line = "";
-        if (",".equals(opt.getDecimalSeparator())){
-            line = line.replace('.',',');
-        }
-        return line;
-    }
 }

--- a/service-coordtransform/src/test/java/fi/nls/paikkatietoikkuna/coordtransform/CoordTransServiceTest.java
+++ b/service-coordtransform/src/test/java/fi/nls/paikkatietoikkuna/coordtransform/CoordTransServiceTest.java
@@ -3,6 +3,11 @@ package fi.nls.paikkatietoikkuna.coordtransform;
 import static org.junit.Assert.assertEquals;
 
 import com.vividsolutions.jts.geom.Coordinate;
+
+import fi.nls.oskari.control.ActionException;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
@@ -21,4 +26,45 @@ public class CoordTransServiceTest {
                 + "&coords=500000.0,6822000.0;501000.0,6823000.0", query);
     }
 
+    @Test
+    public void testTransformToDegree () throws ActionException{
+        String [] units = {"radian", "gradian", "DDMMSS","DD MM SS", "DDMM", "DD MM"};
+        String [] coords = {"1","100","603012.1451345652","06 00 00.0", "6030.1451345652", "06 00.0"};
+        double [] results = {180.0/Math.PI, 90.0, 60.503373648, 6.0, 60.502418909, 6.0};
+        for (int i = 0; i < units.length ; i ++ ){
+            assertEquals ("Unit: " + units[i], results[i],  CoordTransService.transformUnitToDegree(coords[i], units[i]), 0.000000001);
+        }
+    }
+    @Test
+    public void testTransformToUnit () throws ActionException{
+        double coord = 1.99999;
+        String [] units = {"DD", "DDMMSS", "DD MM SS", "DDMM", "DD MM"};
+        String [] results = {"01.999990", "015959.964000", "01 59 59.964000", "0159.999400", "01 59.999400"};
+        for (int i = 0; i < units.length ; i ++ ){
+            assertEquals ("Unit: " + units[i] + " should have 6 decimals", results[i],  CoordTransService.transformDegreeToUnit(coord, units[i], 6));
+        }
+        assertEquals ("Unit: radian", "2.00000000000000",  CoordTransService.transformDegreeToUnit(360/Math.PI, "radian", 14));
+        assertEquals ("Unit: gradian", "400.00000000000000",  CoordTransService.transformDegreeToUnit(360, "gradian", 14));
+        double [] coords = {-100, -10, -1, 0, 1, 10, 100};
+        //DD.sss
+        results = new String [] {"-100.000", "-10.000", "-01.000", "00.000", "01.000", "10.000", "100.000"};
+        for (int i = 0; i < coords.length ; i ++ ){
+            assertEquals ("DD and should have 3 decimals", results[i],  CoordTransService.transformDegreeToUnit(coords[i], "DD", 3));
+        }
+        //DD MM SS.sss
+        results = new String [] {"-100 00 00.000", "-10 00 00.000", "-01 00 00.000", "00 00 00.000", "01 00 00.000", "10 00 00.000", "100 00 00.000"};
+        for (int i = 0; i < coords.length ; i ++ ){
+            assertEquals ("DD MM SS and should have 3 decimals", results[i],  CoordTransService.transformDegreeToUnit(coords[i], "DD MM SS", 3));
+        }
+    }
+    @Test
+    public void testTransform () throws ActionException{
+        double coord = 60.503373648013675;
+        String [] units = {"DDMMSS", "DD MM SS", "DDMM", "DD MM"};
+        for (int i = 0; i < units.length ; i ++ ){
+            String unit = CoordTransService.transformDegreeToUnit(coord, units[i], 14);
+            double deg = CoordTransService.transformUnitToDegree(unit, units[i]);
+            assertEquals ("Unit: " + units[i], coord,  deg, 0.00000000000001);
+        }
+    }
 }

--- a/service-coordtransform/src/test/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandlerTest.java
+++ b/service-coordtransform/src/test/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandlerTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vividsolutions.jts.geom.Coordinate;
 import fi.nls.oskari.control.ActionException;
 import java.io.ByteArrayInputStream;
@@ -12,6 +13,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
+
 import org.junit.Test;
 
 public class CoordinateTransformationActionHandlerTest {
@@ -23,7 +25,7 @@ public class CoordinateTransformationActionHandlerTest {
         List<Coordinate> expected = getRandomCoordinates(n, 0.0, 1000.0);
         byte[] jsonBytes = createJsonArrayOfArrays(expected, dimension);
         CoordinateTransformationActionHandler handler = new CoordinateTransformationActionHandler();
-        List<Coordinate> actual = handler.parseInputCoordinates(new ByteArrayInputStream(jsonBytes), dimension);
+        List<Coordinate> actual = handler.parseInputCoordinates(new ByteArrayInputStream(jsonBytes), dimension, false);
         for (int i = 0; i < n; i++) {
             Coordinate e = expected.get(i);
             Coordinate a = actual.get(i);
@@ -31,6 +33,42 @@ public class CoordinateTransformationActionHandlerTest {
             assertEquals(e.y, a.y, 0.00001);
             assertEquals(e.z, a.z, 0.00001);
         }
+    }
+
+    @Test
+    public void testCreateFileSettings (){
+        CoordTransFile file = getFileSettings();
+        assertEquals("test.txt", file.getFileName());
+        assertEquals('.', file.getDecimalSeparator());
+        assertEquals("tab", file.getCoordinateSeparator());
+        assertEquals(2, file.getHeaderLineCount());
+        assertEquals(5, file.getDecimalCount());
+        assertEquals("degree", file.getUnit());
+        assertEquals(true, file.isAxisFlip());
+        assertEquals(true, file.isPrefixId());
+        assertEquals(false, file.isWriteCardinals());
+        assertEquals(true, file.isWriteLineEndings());
+        assertEquals(true, file.isWriteHeader());
+    }
+    private CoordTransFile getFileSettings (){
+        ObjectMapper mapper = new ObjectMapper();
+        String json = "{\"fileName\":\"test.txt\","
+                + "\"unit\":\"degree\","
+                + "\"decimalSeparator\":\".\","
+                + "\"coordinateSeparator\":\"tab\","
+                + "\"prefixId\":true,"
+                + "\"writeHeader\":true,"
+                + "\"axisFlip\":true,"
+                + "\"writeCardinals\":false,"
+                + "\"writeLineEndings\":true,"
+                + "\"decimalCount\":5,"
+                + "\"headerLineCount\":2}";
+        try {
+             return mapper.readValue(json, CoordTransFile.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     private List<Coordinate> getRandomCoordinates(int n, double min, double max) {
@@ -63,5 +101,4 @@ public class CoordinateTransformationActionHandlerTest {
         json.close();
         return baos.toByteArray();
     }
-
 }


### PR DESCRIPTION
Get coordinates from file and write file response added. CoordTransFile class added which contains import and export file settings and header, id and line ending rows. 

CoordTransService: added methods to format degrees to units and units to degrees. Unit tests added for degree conversions.

Some error codes added to get localized messages in the frontend. Error handling still needs improvements.

Source and target dimension is added to requests because 3D coordinate systems doesn't have height system (separate epsg code). Also transform type is added (A2A, A2F, F2A, F2F). If there is easy and reliable way to handle type (based on payload or settings) in the backend then there is no need to add it to request in the frontend.

Input coords are now stored and added to response if coordinates is transformed from file to array. Should we add coordinates (String) from file instead of double values (e.g. 25.22424 -> 25 10 12,2124)?