### PR TITLE
Limit batch size based on the request line length instead

### DIFF
--- a/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordTransQueryBuilder.java
+++ b/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordTransQueryBuilder.java
@@ -1,0 +1,57 @@
+package fi.nls.paikkatietoikkuna.coordtransform;
+
+import com.vividsolutions.jts.geom.Coordinate;
+
+public class CoordTransQueryBuilder {
+
+    private static final int LENGTH_LIMIT = 7500;
+    private static final char SEP_COORD = ';';
+    private static final char SEP_COORD_PART = ',';
+
+    private final String endPoint;
+    private final String sourceCrs;
+    private final String targetCrs;
+    private final int dimension;
+    private final StringBuilder sb;
+    boolean firstCoordinate;
+
+    public CoordTransQueryBuilder(String endPoint, String sourceCrs, String targetCrs, int dimension) {
+        this.endPoint = endPoint;
+        this.sourceCrs = sourceCrs;
+        this.targetCrs = targetCrs;
+        this.dimension = dimension;
+        this.sb = new StringBuilder();
+        reset();
+    }
+
+    public void reset() {
+        sb.setLength(0);
+        sb.append(endPoint);
+        sb.append("?sourceCRS=").append(sourceCrs);
+        sb.append("&targetCRS=").append(targetCrs);
+        sb.append("&coords=");
+        firstCoordinate = true;
+    }
+
+    public boolean add(Coordinate c) {
+        int len = sb.length();
+        if (!firstCoordinate) {
+            sb.append(SEP_COORD);
+        }
+        sb.append(c.x).append(SEP_COORD_PART).append(c.y);
+        if (dimension == 3) {
+            sb.append(SEP_COORD_PART).append(c.z);
+        }
+        firstCoordinate = false;
+        if (sb.length() >= LENGTH_LIMIT) {
+            sb.setLength(len);
+            return false;
+        }
+        return true;
+    }
+
+    public String build() {
+        return sb.toString();
+    }
+
+}

--- a/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordTransService.java
+++ b/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordTransService.java
@@ -26,25 +26,6 @@ public class CoordTransService {
     private static final BigDecimal DEC_TO_GRAD = BigDecimal.TEN.divide(new BigDecimal(9), DECIMAL_PRECISION);
     private static final BigDecimal DEC_TO_RAD = PI2.divide(new BigDecimal(360), DECIMAL_PRECISION);
 
-    public static String createQuery(String sourceCrs, String targetCrs,
-            final List<Coordinate> coords, final int dimension) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("?sourceCRS=").append(sourceCrs);
-        sb.append("&targetCRS=").append(targetCrs);
-        sb.append("&coords=");
-        for (int i = 0; i < coords.size(); i++) {
-            if (i > 0) {
-                sb.append(SEP_COORD);
-            }
-            Coordinate coord = coords.get(i);
-            sb.append(coord.x).append(SEP_COORD_PART).append(coord.y);
-            if (dimension == 3) {
-                sb.append(SEP_COORD_PART).append(coord.z);
-            }
-        }
-        return sb.toString();
-    }
-
     public static void parseResponse(byte[] resp, List<Coordinate> coords, final int dimension) {
         if (resp[0] == 'V') {
             // "Virhe: " - send only the part after prefix

--- a/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandler.java
+++ b/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandler.java
@@ -139,9 +139,8 @@ public class CoordinateTransformationActionHandler extends RestActionHandler {
                 transformToFile = true;
                 try {
                     exportSettings = mapper.readValue(params.getHttpParam(KEY_EXPORT_SETTINGS), CoordTransFile.class);
-                } catch (IOException e) {
-                    log.warn(e, e.getMessage());
-                    throw new ActionParamsException("Invalid export file settings", "invalid_export_settings");
+                } catch (Exception e) {
+                    throw new ActionParamsException("Invalid export file settings", "invalid_export_settings", e);
                 }
                 coords = getCoordsFromJsonArray (params, sourceDimension, addZeroes);
                 break;
@@ -191,8 +190,7 @@ public class CoordinateTransformationActionHandler extends RestActionHandler {
                 writeJsonResponse(out, coords, inputCoords, targetDimension, hasMoreCoordinates);
             }
         } catch (IOException e) {
-            log.warn(e, e.getMessage());
-            throw new ActionException("Failed to write JSON to client");
+            throw new ActionException("Failed to write JSON to client", e);
         }
     }
 
@@ -224,23 +222,20 @@ public class CoordinateTransformationActionHandler extends RestActionHandler {
         try {
             conn = IOHelper.getConnection(query);
         } catch (IOException e) {
-            log.warn(e, e.getMessage());
-            throw new ActionException("Failed to connect to CoordTrans service");
+            throw new ActionException("Failed to connect to CoordTrans service", e);
         }
         byte[] serviceResponseBytes;
         try {
             serviceResponseBytes = IOHelper.readBytes(conn);
         } catch (IOException e) {
-            log.warn(e, e.getMessage());
-            throw new ActionException("Failed to read response from CoordTrans service");
+            throw new ActionException("Failed to read response from CoordTrans service", e);
         }
 
         try {
             // Change Coordinate.xyz values in place
             CoordTransService.parseResponse(serviceResponseBytes, batch, dimension);
         } catch (IllegalArgumentException e) {
-            log.warn(e, e.getMessage());
-            throw new ActionException(e.getMessage());
+            throw new ActionException(e.getMessage(), e);
         }
     }
 
@@ -248,8 +243,7 @@ public class CoordinateTransformationActionHandler extends RestActionHandler {
         try (InputStream in = params.getRequest().getInputStream()) {
             return parseInputCoordinates(in, dimension, addZeroes);
         } catch (IOException e) {
-            log.warn(e, e.getMessage());
-            throw new ActionException("Failed to parse input JSON!");
+            throw new ActionException("Failed to parse input JSON!", e);
         }
     }
 
@@ -349,23 +343,20 @@ public class CoordinateTransformationActionHandler extends RestActionHandler {
                 }
             }
         } catch (UnsupportedEncodingException e){
-            log.warn(e, e.getMessage());
-            throw new ActionParamsException("Encoding - Invalid file");
+            throw new ActionParamsException("Encoding - Invalid file", e);
         } catch (IOException e){
-            log.warn(e, e.getMessage());
-            throw new ActionParamsException("IO - Invalid file");
+            throw new ActionParamsException("IO - Invalid file", e);
         } catch (NumberFormatException e){
-            log.warn(e, e.getMessage());
-            throw new ActionParamsException("Expected a number");
+            throw new ActionParamsException("Expected a number", e);
         }
         return coordinates;
     }
-    private CoordTransFile getFileSettings (Map<String, String> formParams, String key) throws ActionParamsException{
+
+    private CoordTransFile getFileSettings(Map<String, String> formParams, String key) throws ActionParamsException {
         try {
             return mapper.readValue(formParams.get(key), CoordTransFile.class);
         } catch (Exception e) {
-            log.warn(e, e.getMessage());
-            throw new ActionParamsException("Invalid file settings: " + key, "invalid_file_settings");
+            throw new ActionParamsException("Invalid file settings: " + key, "invalid_file_settings", e);
         }
     }
 
@@ -376,7 +367,6 @@ public class CoordinateTransformationActionHandler extends RestActionHandler {
             upload.setSizeMax(maxFileSize);
             return upload.parseRequest(request);
         } catch (UnsupportedEncodingException | FileUploadException e) {
-            log.warn(e, e.getMessage());
             throw new ActionException("Failed to read request", e);
         }
     }
@@ -592,7 +582,6 @@ public class CoordinateTransformationActionHandler extends RestActionHandler {
                 bw.write(lineSeparator);
             }
         } catch (IOException e) {
-            log.warn(e, e.getMessage());
             throw new ActionException("Failed to write file", e);
         }
     }

--- a/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandler.java
+++ b/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandler.java
@@ -48,7 +48,6 @@ public class CoordinateTransformationActionHandler extends RestActionHandler {
     private static final String PROP_END_POINT = "coordtransform.endpoint";
     private static final String PROP_MAX_FILE_SIZE_MB = "coordtransform.max.filesize.mb";
     private static final String PROP_MAX_COORDS_FILE_TO_ARRAY = "coordtransform.max.coordinates.array";
-    private static final String PROP_MAX_COORDS_TO_QUERY = "coordtransform.max.coordinates.query";
 
     protected static final String PARAM_SOURCE_CRS = "sourceCrs";
     protected static final String PARAM_SOURCE_H_CRS = "sourceHeightCrs";
@@ -78,7 +77,6 @@ public class CoordinateTransformationActionHandler extends RestActionHandler {
     private static final int MB = 1024 * 1024;
     private final int maxFileSize = PropertyUtil.getOptional(PROP_MAX_FILE_SIZE_MB, 50) * MB;
     private final int maxCoordsF2A = PropertyUtil.getOptional(PROP_MAX_COORDS_FILE_TO_ARRAY, 100);
-    private final int maxCoordsToQuery = PropertyUtil.getOptional(PROP_MAX_COORDS_TO_QUERY, 500);
 
     // Store files smaller than 128kb in memory instead of writing them to disk
     private static final int MAX_SIZE_MEMORY = 128 * 1024;
@@ -142,6 +140,7 @@ public class CoordinateTransformationActionHandler extends RestActionHandler {
                 try {
                     exportSettings = mapper.readValue(params.getHttpParam(KEY_EXPORT_SETTINGS), CoordTransFile.class);
                 } catch (IOException e) {
+                    log.warn(e, e.getMessage());
                     throw new ActionParamsException("Invalid export file settings", "invalid_export_settings");
                 }
                 coords = getCoordsFromJsonArray (params, sourceDimension, addZeroes);
@@ -174,7 +173,7 @@ public class CoordinateTransformationActionHandler extends RestActionHandler {
             throw new ActionParamsException("No coordinates", "no_coordinates");
         }
 
-        transformBatch(sourceCrs, targetCrs, queryDimension, targetDimension, coords, maxCoordsToQuery);
+        transform(sourceCrs, targetCrs, queryDimension, targetDimension, coords);
 
         HttpServletResponse response = params.getResponse();
         if (transformToFile){
@@ -192,65 +191,64 @@ public class CoordinateTransformationActionHandler extends RestActionHandler {
                 writeJsonResponse(out, coords, inputCoords, targetDimension, hasMoreCoordinates);
             }
         } catch (IOException e) {
+            log.warn(e, e.getMessage());
             throw new ActionException("Failed to write JSON to client");
-        }
-    }
-
-    protected void transformBatch(String sourceCrs, String targetCrs, int queryDimension, int targetDimension,
-            List<Coordinate> coords, int maxCoordsToQuery) throws ActionException {
-        for (List<Coordinate> coordinates : partition(coords, maxCoordsToQuery)) {
-            transform(sourceCrs, targetCrs, queryDimension, targetDimension, coordinates);
         }
     }
 
     protected void transform(String sourceCrs, String targetCrs,
             int queryDimension, int targetDimension,
-            List<Coordinate> coordinates) throws ActionException {
-        String query = CoordTransService.createQuery(sourceCrs, targetCrs, coordinates, queryDimension);
+            List<Coordinate> coords) throws ActionException {
+        CoordTransQueryBuilder queryBuilder = new CoordTransQueryBuilder(endPoint, sourceCrs, targetCrs, queryDimension);
+
+        List<Coordinate> batch = new ArrayList<>();
+        for (Coordinate c : coords) {
+            boolean fit = queryBuilder.add(c);
+            if (!fit) {
+                transform(queryBuilder.build(), batch, targetDimension);
+                queryBuilder.reset();
+                batch.clear();
+                queryBuilder.add(c);
+            }
+            batch.add(c);
+        }
+        transform(queryBuilder.build(), batch, targetDimension);
+    }
+
+    protected void transform(String query, List<Coordinate> batch, int dimension) throws ActionException {
+        if (batch.size() == 0) {
+            return;
+        }
+
         HttpURLConnection conn;
         try {
-            conn = IOHelper.getConnection(endPoint + query);
+            conn = IOHelper.getConnection(query);
         } catch (IOException e) {
+            log.warn(e, e.getMessage());
             throw new ActionException("Failed to connect to CoordTrans service");
         }
         byte[] serviceResponseBytes;
         try {
             serviceResponseBytes = IOHelper.readBytes(conn);
         } catch (IOException e) {
+            log.warn(e, e.getMessage());
             throw new ActionException("Failed to read response from CoordTrans service");
         }
 
         try {
             // Change Coordinate.xyz values in place
-            CoordTransService.parseResponse(serviceResponseBytes, coordinates, targetDimension);
+            CoordTransService.parseResponse(serviceResponseBytes, batch, dimension);
         } catch (IllegalArgumentException e) {
+            log.warn(e, e.getMessage());
             throw new ActionException(e.getMessage());
         }
-    }
-
-    /**
-     * Split list into sublists
-     * @param list to split
-     * @param n size of each group (last one may be smaller)
-     */
-    public static <T> List<List<T>> partition(List<T> list, int n) {
-        List<List<T>> groups = new ArrayList<>();
-        List<T> group = new ArrayList<>();
-        groups.add(group);
-        for (T item : list) {
-            if (group.size() == n) {
-                group = new ArrayList<>();
-                groups.add(group);
-            }
-            group.add(item);
-        }
-        return groups;
     }
 
     private List<Coordinate> getCoordsFromJsonArray (ActionParameters params, int dimension, boolean addZeroes) throws ActionException{
         try (InputStream in = params.getRequest().getInputStream()) {
             return parseInputCoordinates(in, dimension, addZeroes);
         } catch (IOException e) {
+            log.warn(e, e.getMessage());
             throw new ActionException("Failed to parse input JSON!");
         }
     }
@@ -351,10 +349,13 @@ public class CoordinateTransformationActionHandler extends RestActionHandler {
                 }
             }
         } catch (UnsupportedEncodingException e){
+            log.warn(e, e.getMessage());
             throw new ActionParamsException("Encoding - Invalid file");
         } catch (IOException e){
+            log.warn(e, e.getMessage());
             throw new ActionParamsException("IO - Invalid file");
         } catch (NumberFormatException e){
+            log.warn(e, e.getMessage());
             throw new ActionParamsException("Expected a number");
         }
         return coordinates;
@@ -363,6 +364,7 @@ public class CoordinateTransformationActionHandler extends RestActionHandler {
         try {
             return mapper.readValue(formParams.get(key), CoordTransFile.class);
         } catch (Exception e) {
+            log.warn(e, e.getMessage());
             throw new ActionParamsException("Invalid file settings: " + key, "invalid_file_settings");
         }
     }
@@ -374,6 +376,7 @@ public class CoordinateTransformationActionHandler extends RestActionHandler {
             upload.setSizeMax(maxFileSize);
             return upload.parseRequest(request);
         } catch (UnsupportedEncodingException | FileUploadException e) {
+            log.warn(e, e.getMessage());
             throw new ActionException("Failed to read request", e);
         }
     }
@@ -589,6 +592,7 @@ public class CoordinateTransformationActionHandler extends RestActionHandler {
                 bw.write(lineSeparator);
             }
         } catch (IOException e) {
+            log.warn(e, e.getMessage());
             throw new ActionException("Failed to write file", e);
         }
     }

--- a/service-coordtransform/src/test/java/fi/nls/paikkatietoikkuna/coordtransform/CoordTransQueryBuilderTest.java
+++ b/service-coordtransform/src/test/java/fi/nls/paikkatietoikkuna/coordtransform/CoordTransQueryBuilderTest.java
@@ -1,0 +1,54 @@
+package fi.nls.paikkatietoikkuna.coordtransform;
+
+import static org.junit.Assert.assertEquals;
+
+import com.vividsolutions.jts.geom.Coordinate;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+public class CoordTransQueryBuilderTest {
+
+    @Test
+    public void simpleTest() {
+        CoordTransQueryBuilder b = new CoordTransQueryBuilder("foo", "bar", "baz", 2);
+        List<Coordinate> coords = Arrays.asList(
+                new Coordinate(500000, 6822000),
+                new Coordinate(501000, 6823000)
+        );
+        for (Coordinate c : coords) {
+            b.add(c);
+        }
+        String query = b.build();
+        assertEquals("foo?sourceCRS=bar"
+                + "&targetCRS=baz"
+                + "&coords=500000.0,6822000.0;501000.0,6823000.0", query);
+    }
+
+    @Test
+    public void resetTest() {
+        CoordTransQueryBuilder b = new CoordTransQueryBuilder("foo", "bar", "baz", 2);
+        List<Coordinate> coords = Arrays.asList(
+                new Coordinate(500000, 6822000),
+                new Coordinate(501000, 6823000)
+        );
+        for (Coordinate c : coords) {
+            b.add(c);
+            b.add(c);
+        }
+        assertEquals("foo?sourceCRS=bar"
+                + "&targetCRS=baz"
+                + "&coords=500000.0,6822000.0;500000.0,6822000.0;501000.0,6823000.0;501000.0,6823000.0", b.build());
+
+        b.reset();
+        for (Coordinate c : coords) {
+            b.add(c);
+        }
+
+        assertEquals("foo?sourceCRS=bar"
+                + "&targetCRS=baz"
+                + "&coords=500000.0,6822000.0;501000.0,6823000.0", b.build());
+    }
+
+}

--- a/service-coordtransform/src/test/java/fi/nls/paikkatietoikkuna/coordtransform/CoordTransServiceTest.java
+++ b/service-coordtransform/src/test/java/fi/nls/paikkatietoikkuna/coordtransform/CoordTransServiceTest.java
@@ -2,29 +2,10 @@ package fi.nls.paikkatietoikkuna.coordtransform;
 
 import static org.junit.Assert.assertEquals;
 
-import com.vividsolutions.jts.geom.Coordinate;
-
 import fi.nls.oskari.control.ActionException;
-
-import java.math.BigDecimal;
-import java.math.MathContext;
-import java.util.Arrays;
-import java.util.List;
 import org.junit.Test;
 
 public class CoordTransServiceTest {
-
-    @Test
-    public void testCreateQuery() {
-        List<Coordinate> coords = Arrays.asList(
-                new Coordinate(500000, 6822000),
-                new Coordinate(501000, 6823000)
-        );
-        String query = CoordTransService.createQuery("EPSG:3067", "EPSG:4258", coords, 2);
-        assertEquals("?sourceCRS=EPSG:3067"
-                + "&targetCRS=EPSG:4258"
-                + "&coords=500000.0,6822000.0;501000.0,6823000.0", query);
-    }
 
     @Test
     public void testTransformToDegree () throws ActionException{

--- a/service-coordtransform/src/test/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandlerTest.java
+++ b/service-coordtransform/src/test/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandlerTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.fasterxml.jackson.core.JsonFactory;

--- a/service-coordtransform/src/test/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandlerTest.java
+++ b/service-coordtransform/src/test/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandlerTest.java
@@ -3,22 +3,22 @@ package fi.nls.paikkatietoikkuna.coordtransform;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.vividsolutions.jts.geom.Coordinate;
-import fi.nls.oskari.control.ActionException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
-import org.junit.Ignore;
 import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vividsolutions.jts.geom.Coordinate;
+
+import fi.nls.oskari.control.ActionException;
 
 public class CoordinateTransformationActionHandlerTest {
 
@@ -121,28 +121,12 @@ public class CoordinateTransformationActionHandlerTest {
     }
 
     @Test
-    public void partitionTest() {
-        List<Integer> numbers = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8);
-
-        List<List<Integer>> groups = CoordinateTransformationActionHandler.partition(numbers, 2);
-        assertEquals(4, groups.size());
-        assertEquals(1, groups.get(0).get(0).intValue());
-        assertEquals(8, groups.get(3).get(1).intValue());
-
-        groups = CoordinateTransformationActionHandler.partition(numbers, 3);
-        assertEquals(3, groups.size());
-        assertEquals(3, groups.get(0).size());
-        assertEquals(1, groups.get(0).get(0).intValue());
-        assertEquals(2, groups.get(2).size());
-        assertEquals(8, groups.get(2).get(1).intValue());
-    }
-
-    @Test
-    @Ignore("Requires connection to external service")
+    // @Ignore("Requires connection to external service")
     public void transformTest() throws ActionException {
         CoordinateTransformationActionHandler handler = new CoordinateTransformationActionHandler("https://coordtrans.maanmittauslaitos.fi/CoordTrans-1.0/CoordTrans");
+        int n = 1000;
 
-        List<Coordinate> coordinates = getRandomCoordinates(10, 300000, 600000, 6700000, 6730000, 0, 0);
+        List<Coordinate> coordinates = getRandomCoordinates(n, 300000, 600000, 6700000, 6730000, 0, 0);
         List<Coordinate> originals = coordinates.stream().map(c -> new Coordinate(c)).collect(Collectors.toList());
         handler.transform("EPSG:3067", "EPSG:4258", 2, 2, coordinates);
         assertEquals(originals.size(), coordinates.size());
@@ -158,38 +142,9 @@ public class CoordinateTransformationActionHandlerTest {
         for (int i = 0; i < originals.size(); i++) {
             Coordinate original = originals.get(i);
             Coordinate transformed = coordinates.get(i);
-            // Allow 1/10th of a millimeter error in transformation
-            assertEquals(original.x, transformed.x, 0.0001);
-            assertEquals(original.y, transformed.y, 0.0001);
-        }
-    }
-
-    @Test
-    @Ignore("Requires connection to external service")
-    public void transformBatchTest() throws ActionException {
-        CoordinateTransformationActionHandler handler = new CoordinateTransformationActionHandler("https://coordtrans.maanmittauslaitos.fi/CoordTrans-1.0/CoordTrans");
-        int n = 1000;
-        int groupSize = 100;
-
-        List<Coordinate> coordinates = getRandomCoordinates(n, 300000, 600000, 6700000, 6730000, 0, 0);
-        List<Coordinate> originals = coordinates.stream().map(c -> new Coordinate(c)).collect(Collectors.toList());
-        handler.transformBatch("EPSG:3067", "EPSG:4258", 2, 2, coordinates, groupSize);
-        assertEquals(originals.size(), coordinates.size());
-        for (int i = 0; i < originals.size(); i++) {
-            Coordinate original = originals.get(i);
-            Coordinate transformed = coordinates.get(i);
-            assertNotEquals(original.x, transformed.x, 0);
-            assertNotEquals(original.y, transformed.y, 0);
-        }
-
-        handler.transformBatch("EPSG:4258", "EPSG:3067", 2, 2, coordinates, groupSize);
-        assertEquals(originals.size(), coordinates.size());
-        for (int i = 0; i < originals.size(); i++) {
-            Coordinate original = originals.get(i);
-            Coordinate transformed = coordinates.get(i);
-            // Allow 1/10th of a millimeter error in transformation
-            assertEquals(original.x, transformed.x, 0.0001);
-            assertEquals(original.y, transformed.y, 0.0001);
+            // Allow 1mm error in transformation
+            assertEquals(original.x, transformed.x, 0.001);
+            assertEquals(original.y, transformed.y, 0.001);
         }
     }
 

--- a/service-coordtransform/src/test/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandlerTest.java
+++ b/service-coordtransform/src/test/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandlerTest.java
@@ -121,7 +121,7 @@ public class CoordinateTransformationActionHandlerTest {
     }
 
     @Test
-    // @Ignore("Requires connection to external service")
+    @Ignore("Requires connection to external service")
     public void transformTest() throws ActionException {
         CoordinateTransformationActionHandler handler = new CoordinateTransformationActionHandler("https://coordtrans.maanmittauslaitos.fi/CoordTrans-1.0/CoordTrans");
         int n = 1000;


### PR DESCRIPTION
Batch coordinates together by limiting the number of characters in the generated KVP query instead of fixed batch size. This solution minimizes the number of requests generated and also handles edge cases better.