### PR TITLE
Coordtransform read file to review and handle errors

### DIFF
--- a/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandler.java
+++ b/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandler.java
@@ -114,6 +114,7 @@ public class CoordinateTransformationActionHandler extends RestActionHandler {
         String transformType = params.getHttpParam(PARAM_TRANSFORM_TYPE);
         if ("F2R".equals(transformType)){ // parse file to array without transformation
             readFileToJsonResonse(params);
+            return;
         }
         String sourceCrs = getSourceCrs(params);
         String targetCrs = getTargetCrs(params);


### PR DESCRIPTION
Add file to review transform type where file is parsed to json response without transformation. 

Pass transformation service's error message to frontend.

When exporting to file with write cardinals option, negative coordinates uses S and W positive coordinates. 