### PR TITLE
CoordTransform transformation fixes

### DIFF
--- a/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandler.java
+++ b/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandler.java
@@ -87,6 +87,8 @@ public class CoordinateTransformationActionHandler extends RestActionHandler {
         if (TransformationType.F2R.equals(transformParams.type)) { // parse file to array without transformation
             // basically pretty much the same as any type starting with F
             // FIXME: remove custom handling and use getCoordsFromFile()
+            // don't transform F2R coordinates and can't set to Coordinate (double values) because has to be String (24 14 15,35353)
+            // check if some common file parsing can be done
             readFileToJsonResponse(transformParams);
             return;
         }
@@ -98,6 +100,8 @@ public class CoordinateTransformationActionHandler extends RestActionHandler {
         if (addZeroes) {
             // add N2000 that coordtrans service doesn't fail
             // TODO: service requires 3 inputs if output is 3 axis???
+            // yes, but instead of adding zeroes and source height system here, coordtransform service should add zeroes to result if 2D->3D is really needed
+            // also then dimensions must not be sent by frontend
             sourceCrs = sourceCrs + ",EPSG:3900";
         }
         CoordinatesPayload coords = getCoordinatesFromPayload(transformParams, addZeroes);
@@ -109,6 +113,9 @@ public class CoordinateTransformationActionHandler extends RestActionHandler {
 
         // make the calls to actual service
         // TODO: why would we need to send targetDimension as param?
+        // targetDimension is used in parseResponse
+        // also can be checked e.g. coordinateParts.length == 3 (parseResponse)
+        // in query !Double.isNaN(coord.z)
         transform(sourceCrs, targetCrs, targetDimension, coords.getCoords());
 
         HttpServletResponse response = params.getResponse();

--- a/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandler.java
+++ b/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandler.java
@@ -138,6 +138,9 @@ public class CoordinateTransformationActionHandler extends RestActionHandler {
             // payload is json
             List<Coordinate> coord = getCoordsFromJsonArray(params.actionParameters, dimensionCount, addZeroes);
             payload.addCoordinates(coord);
+            if (params.type.isFileOutput()){
+                payload.setExportSettings(params.exportSettings);
+            }
             return payload;
         }
 
@@ -550,7 +553,7 @@ public class CoordinateTransformationActionHandler extends RestActionHandler {
             boolean writeEndings = opts.isWriteLineEndings() && !lineEndings.isEmpty();
             String unit = opts.getUnit();
             boolean transformUnit = false;
-            if (unit != null && !unit.equals(DEGREE)) {
+            if (unit != null && !unit.equals(DEGREE) && !unit.equals(METRIC)) {
                 transformUnit = true;
             }
             if (opts.isPrefixId()) {

--- a/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/TransformParams.java
+++ b/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/TransformParams.java
@@ -53,8 +53,13 @@ public class TransformParams {
         } catch (IllegalArgumentException e) {
             throw new ActionParamsException("Unknown transform type");
         }
-        sourceCRS = getSourceCrs(params);
-        targetCRS = getTargetCrs(params);
+        if (type.isTransform() == false) {
+            sourceCRS = null;
+            targetCRS = null;
+        } else {
+            sourceCRS = getSourceCrs(params);
+            targetCRS = getTargetCrs(params);
+        }
 
         inputDimensions = params.getHttpParam(PARAM_SOURCE_DIMENSION, 2);
         outputDimensions = params.getHttpParam(PARAM_TARGET_DIMENSION, 2);

--- a/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/TransformationType.java
+++ b/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/TransformationType.java
@@ -18,4 +18,7 @@ public enum TransformationType {
         return toString().charAt(2) == 'F';
     }
 
+    public boolean isTransform() {
+        return toString().charAt(2) != 'R';
+    }
 }

--- a/service-coordtransform/src/test/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandlerTest.java
+++ b/service-coordtransform/src/test/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandlerTest.java
@@ -46,6 +46,7 @@ public class CoordinateTransformationActionHandlerTest {
         assertEquals("test.txt", file.getFileName());
         assertEquals('.', file.getDecimalSeparator());
         assertEquals("tab", file.getCoordinateSeparator());
+        assertEquals("win", file.getLineSeparator());
         assertEquals(2, file.getHeaderLineCount());
         assertEquals(5, file.getDecimalCount());
         assertEquals("degree", file.getUnit());
@@ -66,6 +67,7 @@ public class CoordinateTransformationActionHandlerTest {
                 + "\"axisFlip\":true,"
                 + "\"writeCardinals\":false,"
                 + "\"writeLineEndings\":true,"
+                + "\"lineSeparator\":\"win\","
                 + "\"decimalCount\":5,"
                 + "\"headerLineCount\":2}";
         try {


### PR DESCRIPTION
Don't require source and target crs params with F2R because no transformation is needed.
Add export file settings with A2F and don't transform metric unit.
