### PR TITLE
Fix Remove logUrl

### DIFF
--- a/app-resources/src/main/resources/flyway/paikkis/V2_31__remove_logurl.sql
+++ b/app-resources/src/main/resources/flyway/paikkis/V2_31__remove_logurl.sql
@@ -1,1 +1,1 @@
-UPDATE portti_view_bundle_seq SET config = regexp_replace(config, '"logUrl"\s?:\s?"[^"]*"', '') WHERE bundleinstance = 'statehandler' AND config::json->'logUrl' IS NOT NULL;
+UPDATE portti_view_bundle_seq SET config = regexp_replace(config, '"logUrl"\s?:\s?"[^"]*"', '') WHERE bundleinstance = 'statehandler' AND (config::json->'logUrl')::text IS NOT NULL;


### PR DESCRIPTION
#57 added migration which fails on develop environment.
Current version throws an exception `operator does not exist: json -> boolean`.
This fixes the issue.


