### PR TITLE
Coordtransform max results and read file fix

### DIFF
--- a/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordTransService.java
+++ b/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/CoordTransService.java
@@ -25,7 +25,7 @@ public class CoordTransService {
     private static final BigDecimal DEC_TO_GRAD = BigDecimal.TEN.divide(new BigDecimal(9), DECIMAL_PRECISION);
     private static final BigDecimal DEC_TO_RAD = PI2.divide(new BigDecimal(360), DECIMAL_PRECISION);
 
-    public static void parseResponse(byte[] resp, List<Coordinate> coords, final int dimension) {
+    public static void parseResponse(byte[] resp, List<Coordinate> coords) {
         if (resp[0] == 'V') {
             // "Virhe: " - send only the part after prefix
             throw new IllegalArgumentException(new String(resp, 7, resp.length - 7, StandardCharsets.UTF_8));
@@ -38,8 +38,7 @@ public class CoordTransService {
             String[] coordinateParts = coordinates[i].split(SEP_COORD_PART);
             coord.x = Double.parseDouble(coordinateParts[0]);
             coord.y = Double.parseDouble(coordinateParts[1]);
-            if (dimension == 3) {
-                // FIXME: just check if coordinateParts.length > 3 instead of sending dimension?
+            if (coordinateParts.length > 2) {
                 coord.z = Double.parseDouble(coordinateParts[2]);
             }
         }
@@ -48,6 +47,7 @@ public class CoordTransService {
     public static double transformUnitToDegree(String coord, String unit) throws ActionException {
         coord = coord.trim();
         BigDecimal value;
+        //FIXME: move to switch
         if (GRADIAN.equals(unit)) {
             value = new BigDecimal(coord);
             value = value.divide(DEC_TO_GRAD, DECIMAL_PRECISION);
@@ -62,6 +62,9 @@ public class CoordTransService {
         BigDecimal mm;
         BigDecimal ss;
         switch (unit) {
+            //TODO: Could also remove all whitespaces from coord and use same parsing
+            //trim -> coord = coord.replaceAll("\\s",""); (or compile Pattern for it)
+            //case "DD MM":
             case "DDMM":
                 mm = new BigDecimal(coord.substring(2));
                 dd = dd.add(mm.divide(HOUR_TO_MIN, DECIMAL_PRECISION));

--- a/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/TransformParams.java
+++ b/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/TransformParams.java
@@ -53,12 +53,12 @@ public class TransformParams {
         } catch (IllegalArgumentException e) {
             throw new ActionParamsException("Unknown transform type");
         }
-        if (type.isTransform() == false) {
-            sourceCRS = null;
-            targetCRS = null;
-        } else {
+        if (type.isTransform()) {
             sourceCRS = getSourceCrs(params);
             targetCRS = getTargetCrs(params);
+        } else {
+            sourceCRS = null;
+            targetCRS = null;
         }
 
         inputDimensions = params.getHttpParam(PARAM_SOURCE_DIMENSION, 2);

--- a/service-coordtransform/src/test/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandlerTest.java
+++ b/service-coordtransform/src/test/java/fi/nls/paikkatietoikkuna/coordtransform/CoordinateTransformationActionHandlerTest.java
@@ -131,7 +131,7 @@ public class CoordinateTransformationActionHandlerTest {
 
         List<Coordinate> coordinates = getRandomCoordinates(n, 300000, 600000, 6700000, 6730000, 0, 0);
         List<Coordinate> originals = coordinates.stream().map(c -> new Coordinate(c)).collect(Collectors.toList());
-        handler.transform("EPSG:3067", "EPSG:4258", 2, coordinates);
+        handler.transform("EPSG:3067", "EPSG:4258", coordinates);
         assertEquals(originals.size(), coordinates.size());
         for (int i = 0; i < originals.size(); i++) {
             Coordinate original = originals.get(i);
@@ -140,7 +140,7 @@ public class CoordinateTransformationActionHandlerTest {
             assertNotEquals(original.y, transformed.y, 0);
         }
 
-        handler.transform("EPSG:4258", "EPSG:3067", 2, coordinates);
+        handler.transform("EPSG:4258", "EPSG:3067", coordinates);
         assertEquals(originals.size(), coordinates.size());
         for (int i = 0; i < originals.size(); i++) {
             Coordinate original = originals.get(i);


### PR DESCRIPTION
Set maxCoordsF2A to array output and Integer.MAX_VALUE to file output.

Force F2R (read file to input array without transformations) to read z-values. Frontend sends dimension = 3 and file may not have z-values. So we have to check that file contains x and y values at least and add z ="" if file doesn't contain z. This doesn't affect to transformation.

Removed dimension from transformation as suggested in the comments.