### PR TITLE
Handle service connection error on init

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,13 +16,12 @@
         <java.version>1.8</java.version>
 
         <commons-dbcp2.version>2.0.1</commons-dbcp2.version>
-        <postgresql.version>9.3-1102-jdbc41</postgresql.version>
+        <postgresql.version>42.2.5</postgresql.version>
         <junit.version>4.11</junit.version>
         <slf4j.version>1.7.12</slf4j.version>
-		<jackson.version>1.9.11</jackson.version>
-        <jackson2.version>2.9.2</jackson2.version>
-        <jsoup.version>1.7.2</jsoup.version>
-        <servlet.version>2.5</servlet.version>
+        <jackson.version>2.9.7</jackson.version>
+        <jsoup.version>1.10.3</jsoup.version>
+        <servlet.version>3.1.0</servlet.version>
         <geojson-jackson.version>1.8</geojson-jackson.version>
         <commons-fileupload.version>1.3.2</commons-fileupload.version>
     </properties>

--- a/service-coordtransform/pom.xml
+++ b/service-coordtransform/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson2.version}</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-fileupload</groupId>
@@ -32,7 +32,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <version>${servlet.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/webapp-landing/pom.xml
+++ b/webapp-landing/pom.xml
@@ -17,7 +17,6 @@
         <javax.servlet.version>3.1.0</javax.servlet.version>
         <javax.servlet.jsp.version>2.0</javax.servlet.jsp.version>
         <javax.servlet.jstl.version>1.2</javax.servlet.jstl.version>
-        <jackson.version>2.5.4</jackson.version>
         <log4j.version>1.2.17</log4j.version>
     </properties>
 


### PR DESCRIPTION
Makes TerrainProfile to retry connection to the backing service when used if the service was down when the server was started. Also some lib updates to match ones in oskari-server.

Requires oskariorg/oskari-server#289

