### PR TITLE
TerrainProfile: pool WCS requests

### DIFF
--- a/service-terrain-profile/pom.xml
+++ b/service-terrain-profile/pom.xml
@@ -28,5 +28,9 @@
             <artifactId>shared-test-resources</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.netflix.hystrix</groupId>
+            <artifactId>hystrix-core</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/service-terrain-profile/src/main/java/fi/nls/paikkatietoikkuna/terrainprofile/CommandGetCoverage.java
+++ b/service-terrain-profile/src/main/java/fi/nls/paikkatietoikkuna/terrainprofile/CommandGetCoverage.java
@@ -1,0 +1,72 @@
+package fi.nls.paikkatietoikkuna.terrainprofile;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.concurrent.TimeoutException;
+
+import com.netflix.hystrix.HystrixCommand;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandKey;
+import com.netflix.hystrix.HystrixCommandProperties;
+import com.netflix.hystrix.HystrixThreadPoolProperties;
+
+import fi.nls.oskari.util.IOHelper;
+import fi.nls.oskari.util.PropertyUtil;
+
+/**
+ * HystrixCommand that sends a GetCoverage request to the WCS service via HTTP
+ * and reads the response to a byte array.
+ *
+ * In case the service responds with a 504 status code this
+ * code sleeps for a bit and then tries again up to MAX_RETRIES times
+ */
+public class CommandGetCoverage extends HystrixCommand<byte[]> {
+
+    private static final String GROUP_KEY = "oskari.terrainprofile";
+    private static final String COMMAND_NAME = "getCoverage";
+    private static final int MAX_RETRIES = 5;
+    private static final int SLEEP_BETWEEN_RETRY_MS = 100;
+
+    private final String request;
+
+    public CommandGetCoverage(String request) {
+        super(Setter
+                .withGroupKey(HystrixCommandGroupKey.Factory.asKey(GROUP_KEY))
+                .andCommandKey(HystrixCommandKey.Factory.asKey(COMMAND_NAME))
+                .andThreadPoolPropertiesDefaults(
+                        HystrixThreadPoolProperties.Setter()
+                        .withCoreSize(PropertyUtil.getOptional(GROUP_KEY + ".job.pool.size", 4))
+                        .withMaxQueueSize(PropertyUtil.getOptional(GROUP_KEY + ".job.pool.limit", 100))
+                        .withQueueSizeRejectionThreshold(PropertyUtil.getOptional(GROUP_KEY + ".job.pool.queue", 100)))
+                .andCommandPropertiesDefaults(
+                        HystrixCommandProperties.Setter()
+                        .withExecutionTimeoutInMilliseconds(PropertyUtil.getOptional(GROUP_KEY + ".job.timeoutms", 15000))
+                        .withCircuitBreakerRequestVolumeThreshold(PropertyUtil.getOptional(GROUP_KEY + ".failrequests", 10))
+                        .withCircuitBreakerSleepWindowInMilliseconds(PropertyUtil.getOptional(GROUP_KEY + ".sleepwindow", 10000)))
+                );
+        this.request = request;
+    }
+
+    @Override
+    protected byte[] run() throws TimeoutException, IOException, Exception {
+        HttpURLConnection conn = IOHelper.getConnection(request);
+        int sc = conn.getResponseCode();
+
+        int tryCounter = 0;
+        while (sc == HttpURLConnection.HTTP_GATEWAY_TIMEOUT) {
+            if (++tryCounter == MAX_RETRIES) {
+                throw new TimeoutException();
+            }
+            Thread.sleep(SLEEP_BETWEEN_RETRY_MS);
+            conn = IOHelper.getConnection(request);
+            sc = conn.getResponseCode();
+        }
+
+        if (sc == HttpURLConnection.HTTP_OK) {
+            return IOHelper.readBytes(conn);
+        }
+
+        throw new Exception("Unexpected response to GetCoverage");
+    }
+
+}


### PR DESCRIPTION
Currently the remote WCS system easily responds with a 504 when there are too many active requests within the service. This PR adds Hystrix pooling to the outgoing requests so that we avoid the 504 error as much as possible.

TerrainProfile ActionRoute now responds with the error message `Timeout` when the backing WCS service seems to be struggling.