### PR TITLE
Add missing semicolon

### DIFF
--- a/webapp-map/src/main/webapp/WEB-INF/jsp/index3D.jsp
+++ b/webapp-map/src/main/webapp/WEB-INF/jsp/index3D.jsp
@@ -171,7 +171,7 @@
             }
             window.location.href = url;
         }
-    }
+    };
 
     // Polyfills DOM4 MouseEvent
     (function (window) {


### PR DESCRIPTION
Fixes a script error
* TypeError: {(intermediate value)} is not a function