### PR TITLE
Fix references to service classes that have been renamed in Oskari

### DIFF
--- a/server-extension/src/main/java/flyway/olcesium/V1_0__add_development_olcesium_view.java
+++ b/server-extension/src/main/java/flyway/olcesium/V1_0__add_development_olcesium_view.java
@@ -5,8 +5,8 @@ import fi.nls.oskari.domain.map.view.Bundle;
 import fi.nls.oskari.domain.map.view.View;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.view.AppSetupServiceMybatisImpl;
 import fi.nls.oskari.map.view.ViewService;
-import fi.nls.oskari.map.view.ViewServiceIbatisImpl;
 import fi.nls.oskari.util.PropertyUtil;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 import org.json.JSONObject;
@@ -19,7 +19,7 @@ public class V1_0__add_development_olcesium_view implements JdbcMigration {
     private ViewService service = null;
 
     public void migrate(Connection connection) throws Exception {
-        service = new ViewServiceIbatisImpl();
+        service = new AppSetupServiceMybatisImpl();
 
         final String file = PropertyUtil.get("flyway.olcesium.1_0.file", "paikkis-olcesium-dev.json");
         // configure the view that should be used as default options

--- a/server-extension/src/main/java/flyway/olcesium/V1_10__edit_default_layers_in_3D_view.java
+++ b/server-extension/src/main/java/flyway/olcesium/V1_10__edit_default_layers_in_3D_view.java
@@ -5,8 +5,8 @@ import fi.nls.oskari.domain.map.view.Bundle;
 import fi.nls.oskari.domain.map.view.View;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.view.AppSetupServiceMybatisImpl;
 import fi.nls.oskari.map.view.ViewService;
-import fi.nls.oskari.map.view.ViewServiceIbatisImpl;
 import fi.nls.oskari.util.JSONHelper;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 import org.json.JSONArray;
@@ -31,7 +31,7 @@ public class V1_10__edit_default_layers_in_3D_view implements JdbcMigration {
     private ViewService viewService = null;
 
     public void migrate(Connection connection) throws SQLException {
-        viewService =  new ViewServiceIbatisImpl();
+        viewService =  new AppSetupServiceMybatisImpl();
         updateCesiumViews(connection);
     }
 

--- a/server-extension/src/main/java/flyway/olcesium/V1_11__add_modules.java
+++ b/server-extension/src/main/java/flyway/olcesium/V1_11__add_modules.java
@@ -4,9 +4,9 @@ import fi.nls.oskari.domain.map.view.Bundle;
 import fi.nls.oskari.domain.map.view.View;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.view.AppSetupServiceMybatisImpl;
 import fi.nls.oskari.map.view.ViewException;
 import fi.nls.oskari.map.view.ViewService;
-import fi.nls.oskari.map.view.ViewServiceIbatisImpl;
 import fi.nls.oskari.util.FlywayHelper;
 import fi.nls.oskari.util.JSONHelper;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
@@ -64,7 +64,7 @@ public class V1_11__add_modules implements JdbcMigration {
     private ViewService viewService = null;
 
     public void migrate(Connection connection) {
-        viewService =  new ViewServiceIbatisImpl();
+        viewService =  new AppSetupServiceMybatisImpl();
         updateCesiumViews(connection);
     }
 

--- a/server-extension/src/main/java/flyway/olcesium/V1_14__add_wfs_plugin.java
+++ b/server-extension/src/main/java/flyway/olcesium/V1_14__add_wfs_plugin.java
@@ -4,9 +4,9 @@ import fi.nls.oskari.domain.map.view.Bundle;
 import fi.nls.oskari.domain.map.view.View;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.view.AppSetupServiceMybatisImpl;
 import fi.nls.oskari.map.view.ViewException;
 import fi.nls.oskari.map.view.ViewService;
-import fi.nls.oskari.map.view.ViewServiceIbatisImpl;
 import fi.nls.oskari.util.JSONHelper;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 import org.json.JSONArray;
@@ -30,7 +30,7 @@ public class V1_14__add_wfs_plugin implements JdbcMigration {
     private ViewService viewService = null;
 
     public void migrate(Connection connection) {
-        viewService =  new ViewServiceIbatisImpl();
+        viewService =  new AppSetupServiceMybatisImpl();
         updateCesiumViews(connection);
     }
 

--- a/server-extension/src/main/java/flyway/olcesium/V1_1__set_layers.java
+++ b/server-extension/src/main/java/flyway/olcesium/V1_1__set_layers.java
@@ -6,8 +6,8 @@ import fi.nls.oskari.domain.map.view.View;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.map.layer.formatters.LayerJSONFormatterWMTS;
+import fi.nls.oskari.map.view.AppSetupServiceMybatisImpl;
 import fi.nls.oskari.map.view.ViewService;
-import fi.nls.oskari.map.view.ViewServiceIbatisImpl;
 import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.service.capabilities.CapabilitiesCacheService;
 import fi.nls.oskari.service.capabilities.OskariLayerCapabilities;
@@ -40,7 +40,7 @@ public class V1_1__set_layers implements JdbcMigration {
     private CapabilitiesCacheService capabilitiesService = null;
 
     public void migrate(Connection connection) throws SQLException {
-        viewService =  new ViewServiceIbatisImpl();
+        viewService =  new AppSetupServiceMybatisImpl();
         capabilitiesService = OskariComponentManager.getComponentOfType(CapabilitiesCacheService.class);
         List<OskariLayer> layers = getNlsBaseLayers(connection);
         LOG.info("Start populating matrixies for Oskari WMTS layers - count:", layers.size());

--- a/server-extension/src/main/java/flyway/olcesium/V1_2__3D_index_page.java
+++ b/server-extension/src/main/java/flyway/olcesium/V1_2__3D_index_page.java
@@ -1,33 +1,17 @@
 package flyway.olcesium;
 
-import fi.nls.oskari.domain.map.OskariLayer;
-import fi.nls.oskari.domain.map.view.Bundle;
 import fi.nls.oskari.domain.map.view.View;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
-import fi.nls.oskari.map.layer.formatters.LayerJSONFormatterWMTS;
+import fi.nls.oskari.map.view.AppSetupServiceMybatisImpl;
 import fi.nls.oskari.map.view.ViewService;
-import fi.nls.oskari.map.view.ViewServiceIbatisImpl;
-import fi.nls.oskari.service.OskariComponentManager;
-import fi.nls.oskari.service.capabilities.CapabilitiesCacheService;
-import fi.nls.oskari.service.capabilities.OskariLayerCapabilities;
-import fi.nls.oskari.util.JSONHelper;
-import fi.nls.oskari.wmts.WMTSCapabilitiesParser;
-import fi.nls.oskari.wmts.domain.WMTSCapabilities;
-import fi.nls.oskari.wmts.domain.WMTSCapabilitiesLayer;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 public class V1_2__3D_index_page implements JdbcMigration {
 
@@ -38,7 +22,7 @@ public class V1_2__3D_index_page implements JdbcMigration {
     private ViewService viewService = null;
 
     public void migrate(Connection connection) throws SQLException {
-        viewService =  new ViewServiceIbatisImpl();
+        viewService =  new AppSetupServiceMybatisImpl();
         updateCesiumViews(connection);
     }
 

--- a/server-extension/src/main/java/flyway/olcesium/V1_3__force_proxy.java
+++ b/server-extension/src/main/java/flyway/olcesium/V1_3__force_proxy.java
@@ -4,8 +4,8 @@ import fi.nls.oskari.domain.map.view.Bundle;
 import fi.nls.oskari.domain.map.view.View;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.view.AppSetupServiceMybatisImpl;
 import fi.nls.oskari.map.view.ViewService;
-import fi.nls.oskari.map.view.ViewServiceIbatisImpl;
 import fi.nls.oskari.util.JSONHelper;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 import org.json.JSONObject;
@@ -26,7 +26,7 @@ public class V1_3__force_proxy implements JdbcMigration {
     private ViewService viewService = null;
 
     public void migrate(Connection connection) {
-        viewService =  new ViewServiceIbatisImpl();
+        viewService =  new AppSetupServiceMybatisImpl();
         updateCesiumViews(connection);
     }
 

--- a/server-extension/src/main/java/flyway/olcesium/V1_4__enable_3D_tiles.java
+++ b/server-extension/src/main/java/flyway/olcesium/V1_4__enable_3D_tiles.java
@@ -4,8 +4,8 @@ import fi.nls.oskari.domain.map.view.Bundle;
 import fi.nls.oskari.domain.map.view.View;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.view.AppSetupServiceMybatisImpl;
 import fi.nls.oskari.map.view.ViewService;
-import fi.nls.oskari.map.view.ViewServiceIbatisImpl;
 import fi.nls.oskari.util.JSONHelper;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 import org.json.JSONArray;
@@ -30,7 +30,7 @@ public class V1_4__enable_3D_tiles implements JdbcMigration {
     private ViewService viewService = null;
 
     public void migrate(Connection connection) throws SQLException {
-        viewService =  new ViewServiceIbatisImpl();
+        viewService =  new AppSetupServiceMybatisImpl();
         updateCesiumViews(connection);
     }
 

--- a/server-extension/src/main/java/flyway/olcesium/V1_5__modify_start_view.java
+++ b/server-extension/src/main/java/flyway/olcesium/V1_5__modify_start_view.java
@@ -5,8 +5,8 @@ import fi.nls.oskari.domain.map.view.Bundle;
 import fi.nls.oskari.domain.map.view.View;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.view.AppSetupServiceMybatisImpl;
 import fi.nls.oskari.map.view.ViewService;
-import fi.nls.oskari.map.view.ViewServiceIbatisImpl;
 import fi.nls.oskari.util.JSONHelper;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 import org.json.JSONArray;
@@ -29,7 +29,7 @@ public class V1_5__modify_start_view implements JdbcMigration {
     private ViewService viewService = null;
 
     public void migrate(Connection connection) throws SQLException {
-        viewService =  new ViewServiceIbatisImpl();
+        viewService =  new AppSetupServiceMybatisImpl();
         updateCesiumViews(connection);
     }
 

--- a/server-extension/src/main/java/flyway/olcesium/V1_6__add_search_tool.java
+++ b/server-extension/src/main/java/flyway/olcesium/V1_6__add_search_tool.java
@@ -4,8 +4,8 @@ import fi.nls.oskari.domain.map.view.Bundle;
 import fi.nls.oskari.domain.map.view.View;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.view.AppSetupServiceMybatisImpl;
 import fi.nls.oskari.map.view.ViewService;
-import fi.nls.oskari.map.view.ViewServiceIbatisImpl;
 import fi.nls.oskari.util.FlywayHelper;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 
@@ -28,7 +28,7 @@ public class V1_6__add_search_tool implements JdbcMigration {
     private ViewService viewService = null;
 
     public void migrate(Connection connection) {
-        viewService =  new ViewServiceIbatisImpl();
+        viewService =  new AppSetupServiceMybatisImpl();
         updateCesiumViews(connection);
     }
 

--- a/server-extension/src/main/java/flyway/olcesium/V1_8__2D_view_link.java
+++ b/server-extension/src/main/java/flyway/olcesium/V1_8__2D_view_link.java
@@ -2,8 +2,8 @@ package flyway.olcesium;
 
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.view.AppSetupServiceMybatisImpl;
 import fi.nls.oskari.map.view.ViewService;
-import fi.nls.oskari.map.view.ViewServiceIbatisImpl;
 import fi.nls.oskari.util.FlywayHelper;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 
@@ -24,7 +24,7 @@ public class V1_8__2D_view_link implements JdbcMigration {
     private ViewService viewService = null;
 
     public void migrate(Connection connection) {
-        viewService =  new ViewServiceIbatisImpl();
+        viewService =  new AppSetupServiceMybatisImpl();
         updateCesiumViews(connection);
     }
 

--- a/server-extension/src/main/java/flyway/paikkis/V2_0__default_views.java
+++ b/server-extension/src/main/java/flyway/paikkis/V2_0__default_views.java
@@ -2,15 +2,10 @@ package flyway.paikkis;
 
 import fi.nls.oskari.db.DBHandler;
 import fi.nls.oskari.db.LayerHelper;
-import fi.nls.oskari.db.ViewHelper;
-import fi.nls.oskari.domain.map.view.View;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
-import fi.nls.oskari.map.view.ViewService;
-import fi.nls.oskari.map.view.ViewServiceIbatisImpl;
 import fi.nls.oskari.util.PropertyUtil;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
-import org.json.JSONObject;
 
 import java.sql.Connection;
 

--- a/server-extension/src/main/java/flyway/paikkis/V2_3__add_register_to_default_views.java
+++ b/server-extension/src/main/java/flyway/paikkis/V2_3__add_register_to_default_views.java
@@ -1,7 +1,6 @@
 package flyway.paikkis;
 
 import fi.nls.oskari.util.FlywayHelper;
-import fi.nls.oskari.util.PropertyUtil;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 
 import java.sql.Connection;

--- a/server-extension/src/main/java/flyway/paikkis/V2_4__fix_coordinatetool_decimals_for_3067_projection.java
+++ b/server-extension/src/main/java/flyway/paikkis/V2_4__fix_coordinatetool_decimals_for_3067_projection.java
@@ -4,8 +4,8 @@ import fi.nls.oskari.domain.map.view.Bundle;
 import fi.nls.oskari.domain.map.view.View;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.view.AppSetupServiceMybatisImpl;
 import fi.nls.oskari.map.view.ViewService;
-import fi.nls.oskari.map.view.ViewServiceIbatisImpl;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -32,7 +32,7 @@ public class V2_4__fix_coordinatetool_decimals_for_3067_projection implements Jd
     private int updatedViewCount = 0;
 
     public void migrate(Connection connection) throws Exception{
-        service =  new ViewServiceIbatisImpl();
+        service =  new AppSetupServiceMybatisImpl();
         try {
             updateViews(connection);
         }

--- a/server-extension/src/main/java/flyway/paikkis/V2_9__add_development_ol3_view.java
+++ b/server-extension/src/main/java/flyway/paikkis/V2_9__add_development_ol3_view.java
@@ -5,8 +5,8 @@ import fi.nls.oskari.domain.map.view.Bundle;
 import fi.nls.oskari.domain.map.view.View;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.view.AppSetupServiceMybatisImpl;
 import fi.nls.oskari.map.view.ViewService;
-import fi.nls.oskari.map.view.ViewServiceIbatisImpl;
 import fi.nls.oskari.util.PropertyUtil;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 import org.json.JSONObject;
@@ -19,7 +19,7 @@ public class V2_9__add_development_ol3_view implements JdbcMigration {
     private ViewService service = null;
 
     public void migrate(Connection connection) throws Exception {
-        service = new ViewServiceIbatisImpl();
+        service = new AppSetupServiceMybatisImpl();
 
         final String file = PropertyUtil.get("flyway.paikkis.2_9.file", "paikkis-ol3-dev.json");
         // configure the view that should be used as default options

--- a/server-extension/src/main/java/flyway/ptimigration/V1_4__fix_coordinatetool_decimals_for_3067_projection.java
+++ b/server-extension/src/main/java/flyway/ptimigration/V1_4__fix_coordinatetool_decimals_for_3067_projection.java
@@ -4,8 +4,8 @@ import fi.nls.oskari.domain.map.view.Bundle;
 import fi.nls.oskari.domain.map.view.View;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.map.view.AppSetupServiceMybatisImpl;
 import fi.nls.oskari.map.view.ViewService;
-import fi.nls.oskari.map.view.ViewServiceIbatisImpl;
 import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -32,7 +32,7 @@ public class V1_4__fix_coordinatetool_decimals_for_3067_projection implements Jd
     private int updatedViewCount = 0;
 
     public void migrate(Connection connection) throws Exception{
-        service =  new ViewServiceIbatisImpl();
+        service =  new AppSetupServiceMybatisImpl();
         try {
             updateViews(connection);
         }

--- a/server-extension/src/main/java/flyway/ptistats/V1_23__update_tk_selected_indicators.java
+++ b/server-extension/src/main/java/flyway/ptistats/V1_23__update_tk_selected_indicators.java
@@ -14,7 +14,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * As Tilastokeskus PXWeb config is changed to parse a PX-table variables into indicators -> any saved indicator refs


### PR DESCRIPTION
Fix migrations that refer Oskari ViewService etc. to work with Oskari 1.52