### PR TITLE
Layer permission handling update

### DIFF
--- a/server-extension/src/main/java/flyway/ptistats/V1_13__link_roles_to_sotkanet_layers.java
+++ b/server-extension/src/main/java/flyway/ptistats/V1_13__link_roles_to_sotkanet_layers.java
@@ -23,9 +23,14 @@ import java.util.Optional;
  */
 public class V1_13__link_roles_to_sotkanet_layers implements JdbcMigration {
     private static final Logger LOG = LogFactory.getLogger(V1_13__link_roles_to_sotkanet_layers.class);
+    private static final int DUMMY_ID = -1;
 
     public void migrate(Connection connection)
             throws SQLException {
+        if (true) {
+            // Can't be run to an empty database. Permission handling changed.
+            return;
+        }
         PermissionService service = new PermissionServiceMybatisImpl();
         for(Resource resToUpdate : getResources()) {
             Optional<Resource> dbRes = service.findResource(ResourceType.maplayer, resToUpdate.getMapping());
@@ -49,9 +54,9 @@ public class V1_13__link_roles_to_sotkanet_layers implements JdbcMigration {
     // statslayers described as layer resources for permissions handling
     private List<Resource> getResources() {
         List<Resource> list = new ArrayList<>();
-        list.add(new OskariLayerResource(OskariLayer.TYPE_STATS, "http://geo.stat.fi/geoserver/wms", "tilastointialueet:avi4500k"));
-        list.add(new OskariLayerResource(OskariLayer.TYPE_STATS, "http://geo.stat.fi/geoserver/wms", "tilastointialueet:maakunta4500k"));
-        list.add(new OskariLayerResource(OskariLayer.TYPE_STATS, "http://geo.stat.fi/geoserver/wms", "tilastointialueet:ely4500k"));
+        list.add(new OskariLayerResource(DUMMY_ID));
+        list.add(new OskariLayerResource(DUMMY_ID));
+        list.add(new OskariLayerResource(DUMMY_ID));
         return list;
     }
 

--- a/server-extension/src/main/java/flyway/ptistats/V1_21__link_roles_to_resource_based_thematic_map_layers.java
+++ b/server-extension/src/main/java/flyway/ptistats/V1_21__link_roles_to_resource_based_thematic_map_layers.java
@@ -28,6 +28,7 @@ public class V1_21__link_roles_to_resource_based_thematic_map_layers implements 
 
     private static final String RESOURCES_URL_PREFIX = "resources://";
     private static final String DIR = "stats-regionsets/";
+    private static final int DUMMY_ID = -1;
 
     private enum ResourceStatLayer {
 
@@ -48,12 +49,16 @@ public class V1_21__link_roles_to_resource_based_thematic_map_layers implements 
         }
 
         private Resource getResourceTemplate() {
-            return new OskariLayerResource(OskariLayer.TYPE_STATS, getUrl(), name);
+            return new OskariLayerResource(DUMMY_ID);
         }
 
     }
 
     public void migrate(Connection connection) throws SQLException {
+        if (true) {
+            // Can't be run to an empty database. Permission handling changed.
+            return;
+        }
         ResourceStatLayer[] layers = ResourceStatLayer.values();
         updateLayerUrls(connection, layers);
         updatePermissions(connection, layers);

--- a/server-extension/src/main/java/flyway/ptistats/V1_2__link_roles_to_layers.java
+++ b/server-extension/src/main/java/flyway/ptistats/V1_2__link_roles_to_layers.java
@@ -23,9 +23,14 @@ import java.util.Optional;
  */
 public class V1_2__link_roles_to_layers implements JdbcMigration {
     private static final Logger LOG = LogFactory.getLogger(V1_2__link_roles_to_layers.class);
+    private static final int DUMMY_ID = -1;
 
     public void migrate(Connection connection)
             throws SQLException {
+        if (true) {
+            // Can't be run to an empty database. Permission handling changed.
+            return;
+        }
         PermissionService service = new PermissionServiceMybatisImpl();
         for(Resource resToUpdate : getResources()) {
             Optional<Resource> dbRes = service.findResource(ResourceType.maplayer, resToUpdate.getMapping());
@@ -49,8 +54,8 @@ public class V1_2__link_roles_to_layers implements JdbcMigration {
     // statslayers described as layer resources for permissions handling
     private List<Resource> getResources() {
         List<Resource> list = new ArrayList<>();
-        list.add(new OskariLayerResource(OskariLayer.TYPE_STATS, "http://geo.stat.fi/geoserver/wms", "tilastointialueet:kunta4500k_2017"));
-        list.add(new OskariLayerResource(OskariLayer.TYPE_STATS, "http://geo.stat.fi/geoserver/wms", "tilastointialueet:seutukunta1000k"));
+        list.add(new OskariLayerResource(DUMMY_ID));
+        list.add(new OskariLayerResource(DUMMY_ID));
         return list;
     }
 

--- a/server-extension/src/main/java/flyway/ptistats/V1_8__link_roles_to_hki_layers.java
+++ b/server-extension/src/main/java/flyway/ptistats/V1_8__link_roles_to_hki_layers.java
@@ -23,9 +23,14 @@ import java.util.Optional;
  */
 public class V1_8__link_roles_to_hki_layers implements JdbcMigration {
     private static final Logger LOG = LogFactory.getLogger(V1_8__link_roles_to_hki_layers.class);
+    private static final int DUMMY_ID = -1;
 
     public void migrate(Connection connection)
             throws SQLException {
+        if (true) {
+            // Can't be run to an empty database. Permission handling changed.
+            return;
+        }
         PermissionService service = new PermissionServiceMybatisImpl();
         for(Resource resToUpdate : getResources()) {
             Optional<Resource> dbRes = service.findResource(ResourceType.maplayer, resToUpdate.getMapping());
@@ -49,8 +54,8 @@ public class V1_8__link_roles_to_hki_layers implements JdbcMigration {
     // statslayers described as layer resources for permissions handling
     private List<Resource> getResources() {
         List<Resource> list = new ArrayList<>();
-        list.add(new OskariLayerResource(OskariLayer.TYPE_STATS, "http://geoserver.hel.fi/geoserver/wms", "seutukartta:Seutu_suuralueet"));
-        list.add(new OskariLayerResource(OskariLayer.TYPE_STATS, "http://geoserver.hel.fi/geoserver/wms", "seutukartta:Seutu_pienalueet"));
+        list.add(new OskariLayerResource(DUMMY_ID));
+        list.add(new OskariLayerResource(DUMMY_ID));
         return list;
     }
 


### PR DESCRIPTION
Disabling old database migrations.
The migrations can't be run to an empty database after https://github.com/oskariorg/oskari-server/pull/435. The layer permission mappings have changed.