### PR TITLE
Terrain profile reprojection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,11 @@
             <name>Oskari.org snapshot repository</name>
             <url>http://oskari.org/nexus/content/repositories/snapshots/</url>
         </repository>
+        <repository>
+            <id>osgeo</id>
+            <name>Open Source Geospatial Foundation Repository</name>
+            <url>http://download.osgeo.org/webdav/geotools/</url>
+        </repository>
     </repositories>
 
     <build>

--- a/service-terrain-profile/pom.xml
+++ b/service-terrain-profile/pom.xml
@@ -37,5 +37,17 @@
             <groupId>com.netflix.hystrix</groupId>
             <artifactId>hystrix-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.oskari</groupId>
+            <artifactId>oskari-geojson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-referencing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-opengis</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/service-terrain-profile/src/main/java/fi/nls/paikkatietoikkuna/terrainprofile/TerrainProfileHandler.java
+++ b/service-terrain-profile/src/main/java/fi/nls/paikkatietoikkuna/terrainprofile/TerrainProfileHandler.java
@@ -3,6 +3,10 @@ package fi.nls.paikkatietoikkuna.terrainprofile;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Point;
 import fi.nls.oskari.annotation.OskariActionRoute;
 import fi.nls.oskari.control.ActionException;
 import fi.nls.oskari.control.ActionHandler;
@@ -13,6 +17,7 @@ import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.service.ServiceException;
 import fi.nls.oskari.service.ServiceRuntimeException;
 import fi.nls.oskari.util.IOHelper;
+import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.PropertyUtil;
 import fi.nls.oskari.util.ResponseHelper;
 import java.io.ByteArrayOutputStream;
@@ -21,8 +26,19 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.opengis.referencing.operation.TransformException;
+import org.oskari.geojson.GeoJSONReader;
+
 import org.geojson.Feature;
 import org.geojson.LineString;
+import org.geotools.geometry.jts.JTS;
+import org.geotools.referencing.CRS;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.operation.MathTransform;
+import org.oskari.geojson.GeoJSONWriter;
 
 @OskariActionRoute("TerrainProfile")
 public class TerrainProfileHandler extends ActionHandler {
@@ -35,6 +51,7 @@ public class TerrainProfileHandler extends ActionHandler {
     protected static final String PROPERTY_DEM_COVERAGE_ID = "terrain.profile.wcs.demCoverageId";
     protected static final String PROPERTY_NODATA_VALUE = "terrain.profile.wcs.noData";
 
+    protected static final String JSON_PROPERTY_PROPERTIES = "properties";
     protected static final String JSON_PROPERTY_NUM_POINTS = "numPoints";
     protected static final String JSON_PROPERTY_SCALE_FACTOR = "scaleFactor";
     protected static final String JSON_PROPERTY_DISTANCE_FROM_START = "distanceFromStart";
@@ -93,15 +110,35 @@ public class TerrainProfileHandler extends ActionHandler {
 
     @Override
     public void handleAction(ActionParameters params) throws ActionException {
-        String routeStr = params.getRequiredParam(PARAM_ROUTE);
-        Feature route = parseFeature(routeStr);
-        LineString geom = (LineString) route.getGeometry();
-        double[] points = GeoJSONHelper.getCoordinates2D(geom);
-        int numPoints = Math.min(getNumPoints(route), NUM_POINTS_MAX);
-        double scaleFactor = getScaleFactor(route);
+        JSONObject route = JSONHelper.createJSONObject(params.getRequiredParam(PARAM_ROUTE));
+        Geometry geom = getGeometry(route);
+        try {
+            CoordinateReferenceSystem dataCRS = CRS.decode("EPSG:3857");
+            CoordinateReferenceSystem serviceCRS = CRS.decode("EPSG:3067", true);
+            boolean lenient = true; // allow for some error due to different datums
+            MathTransform transform = CRS.findMathTransform(dataCRS, serviceCRS, lenient);
+            geom = JTS.transform(geom, transform);
+        } catch (FactoryException | TransformException e) {
+            throw new ActionException(e.getMessage(), e);
+        }
+
+        GeoJSONWriter w;
+
+        if (geom == null) {
+            return;
+        }
+        JSONObject properties = route.optJSONObject(JSON_PROPERTY_PROPERTIES);
+        int numPoints = Math.min(getNumPoints(properties), NUM_POINTS_MAX);
+        double scaleFactor = getScaleFactor(properties);
+        double[] points = new double[numPoints];
+        int ptIndex = -1;
+        for (Coordinate coord : geom.getCoordinates()) {
+            points[++ptIndex] = coord.x;
+            points[++ptIndex] = coord.y;
+        }
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Number of coords:", (points.length / 2),
+            LOG.debug("Number of coords:", geom.getNumPoints(),
                     "line:", Arrays.toString(points), "numPoints", numPoints);
         }
 
@@ -112,64 +149,68 @@ public class TerrainProfileHandler extends ActionHandler {
         }
     }
 
-    protected Feature parseFeature(String routeStr) throws ActionParamsException {
+    protected Geometry getGeometry(JSONObject route) throws ActionParamsException {
         try {
-            Feature route = om.readValue(routeStr, Feature.class);
-            if (!(route.getGeometry() instanceof LineString)) {
+            Geometry geom = GeoJSONReader.toGeometry(route.getJSONObject("geometry"));
+            if (!(geom.getGeometryType().equals("LineString"))) {
                 throw new ActionParamsException("Invalid input"
                         + " - expected LineString geometry");
             }
-            LineString ls = (LineString) route.getGeometry();
-            int numPoints = ls.getCoordinates().size();
-            if (numPoints < 2) {
+            if (geom.getNumPoints() < 2) {
                 throw new ActionParamsException("Invalid input"
                         + " - expected LineString with atleast two coordinates");
             }
-            if (numPoints > NUM_POINTS_MAX) {
+            if (geom.getNumPoints() > NUM_POINTS_MAX) {
                 throw new ActionParamsException("Invalid input"
                         + " - too many coordinates, maximum is " + NUM_POINTS_MAX);
             }
-            return route;
-        } catch (IllegalArgumentException | IOException e) {
+            return geom;
+        } catch (JSONException e) {
             throw new ActionParamsException("Invalid input - expected GeoJSON feature", e);
         }
     }
 
-    protected int getNumPoints(Feature route) throws ActionParamsException {
-        Object numPoints = route.getProperty(JSON_PROPERTY_NUM_POINTS);
-        if (numPoints == null) {
+    protected int getNumPoints(JSONObject props) throws ActionParamsException {
+        if (props == null || !props.has(JSON_PROPERTY_NUM_POINTS)) {
             return 0;
         }
-        if (numPoints instanceof Number) {
-            return ((Number) numPoints).intValue();
-        }
-        if (numPoints instanceof String) {
-            try {
-                return Integer.parseInt((String) numPoints);
-            } catch (NumberFormatException ignore) {}
+        try {
+            return props.getInt(JSON_PROPERTY_NUM_POINTS);
+        } catch (JSONException e) {
+            // Throwing ActionParamsException below
         }
         throw new ActionParamsException(String.format(
                 "Invalid property value '%s'", JSON_PROPERTY_NUM_POINTS));
     }
 
-    protected double getScaleFactor(Feature route) {
-        Object scaleFactor = route.getProperty(JSON_PROPERTY_SCALE_FACTOR);
-        if (scaleFactor != null) {
-            if (scaleFactor instanceof Number) {
-                return ((Number) scaleFactor).doubleValue();
-            }
-            if (scaleFactor instanceof String) {
-                try {
-                    return Double.parseDouble((String) scaleFactor);
-                } catch (NumberFormatException ignore) {
-                    // Ignore
-                }
+    protected double getScaleFactor(JSONObject props) {
+        if (props != null && props.has(JSON_PROPERTY_SCALE_FACTOR)) {
+            try {
+                return props.getDouble(JSON_PROPERTY_SCALE_FACTOR);
+            } catch (JSONException e) {
+                // Ignore
             }
         }
         return 0;
     }
 
     protected void writeResponse(ActionParameters params, List<DataPoint> dp) throws ActionException {
+
+        try {
+            CoordinateReferenceSystem dataCRS = CRS.decode("EPSG:3857");
+            CoordinateReferenceSystem serviceCRS = CRS.decode("EPSG:3067", true);
+            boolean lenient = true; // allow for some error due to different datums
+            MathTransform transform = CRS.findMathTransform(serviceCRS, dataCRS, lenient);
+            GeometryFactory gf = new GeometryFactory();
+            for (DataPoint cur : dp) {
+                Geometry geom = gf.createPoint(new Coordinate(cur.getE(), cur.getN()));
+                geom = JTS.transform(geom, transform);
+                cur.setE(geom.getCoordinate().x);
+                cur.setN(geom.getCoordinate().y);
+            }
+        } catch (FactoryException | TransformException e) {
+            throw new ActionException(e.getMessage(), e);
+        }
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (JsonGenerator json = om.getFactory().createGenerator(baos)) {
             writeMultiPointFeature(dp, json, noDataValue);

--- a/service-terrain-profile/src/main/java/fi/nls/paikkatietoikkuna/terrainprofile/TerrainProfileHandler.java
+++ b/service-terrain-profile/src/main/java/fi/nls/paikkatietoikkuna/terrainprofile/TerrainProfileHandler.java
@@ -6,12 +6,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.Point;
 import fi.nls.oskari.annotation.OskariActionRoute;
-import fi.nls.oskari.control.ActionException;
-import fi.nls.oskari.control.ActionHandler;
-import fi.nls.oskari.control.ActionParameters;
-import fi.nls.oskari.control.ActionParamsException;
+import fi.nls.oskari.control.*;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.service.ServiceException;
@@ -31,14 +27,11 @@ import org.json.JSONObject;
 import org.opengis.referencing.operation.TransformException;
 import org.oskari.geojson.GeoJSONReader;
 
-import org.geojson.Feature;
-import org.geojson.LineString;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.referencing.CRS;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.MathTransform;
-import org.oskari.geojson.GeoJSONWriter;
 
 @OskariActionRoute("TerrainProfile")
 public class TerrainProfileHandler extends ActionHandler {
@@ -48,6 +41,7 @@ public class TerrainProfileHandler extends ActionHandler {
     protected static final String PARAM_ROUTE = "route";
 
     protected static final String PROPERTY_ENDPOINT = "terrain.profile.wcs.endPoint";
+    protected static final String PROPERTY_ENDPOINT_SRS = "terrain.profile.wcs.srs";
     protected static final String PROPERTY_DEM_COVERAGE_ID = "terrain.profile.wcs.demCoverageId";
     protected static final String PROPERTY_NODATA_VALUE = "terrain.profile.wcs.noData";
 
@@ -57,10 +51,12 @@ public class TerrainProfileHandler extends ActionHandler {
     protected static final String JSON_PROPERTY_DISTANCE_FROM_START = "distanceFromStart";
 
     private static final int NUM_POINTS_MAX = 1000;
+    private static final String DEFAULT_SRS = "EPSG:3067";
 
     private final ObjectMapper om;
     private TerrainProfileService tps;
     private float noDataValue;
+    private String serviceSrs;
 
     public TerrainProfileHandler() {
         this(new ObjectMapper(), null);
@@ -83,6 +79,7 @@ public class TerrainProfileHandler extends ActionHandler {
             // not fatal, proceed with init and try again later
             LOG.error("Failed to init TerrainProfileService: " + ex.getMessage(), ex);
         }
+        serviceSrs = PropertyUtil.get(PROPERTY_ENDPOINT_SRS, DEFAULT_SRS).toUpperCase();
         noDataValue = getNoDataValue();
         LOG.debug("NODATA value:", noDataValue);
     }
@@ -112,21 +109,13 @@ public class TerrainProfileHandler extends ActionHandler {
     public void handleAction(ActionParameters params) throws ActionException {
         JSONObject route = JSONHelper.createJSONObject(params.getRequiredParam(PARAM_ROUTE));
         Geometry geom = getGeometry(route);
-        try {
-            CoordinateReferenceSystem dataCRS = CRS.decode("EPSG:3857");
-            CoordinateReferenceSystem serviceCRS = CRS.decode("EPSG:3067");
-            boolean lenient = true; // allow for some error due to different datums
-            MathTransform transform = CRS.findMathTransform(dataCRS, serviceCRS, lenient);
-            geom = JTS.transform(geom, transform);
-        } catch (FactoryException | TransformException e) {
-            throw new ActionException(e.getMessage(), e);
+
+        String targetSRS = params.getHttpParam(ActionConstants.PARAM_SRS, DEFAULT_SRS);
+        boolean reproject = !targetSRS.equals(serviceSrs);
+        if (reproject) {
+            geom = getReprojected(geom, targetSRS, serviceSrs);
         }
 
-        GeoJSONWriter w;
-
-        if (geom == null) {
-            return;
-        }
         JSONObject properties = route.optJSONObject(JSON_PROPERTY_PROPERTIES);
         int numPoints = Math.min(getNumPoints(properties), NUM_POINTS_MAX);
         double scaleFactor = getScaleFactor(properties);
@@ -143,7 +132,7 @@ public class TerrainProfileHandler extends ActionHandler {
         }
 
         try {
-            writeResponse(params, getService().getTerrainProfile(points, numPoints, scaleFactor));
+            writeResponse(params, getService().getTerrainProfile(points, numPoints, scaleFactor), reproject);
         } catch (ServiceException e) {
             throw new ActionException(e.getMessage(), e);
         }
@@ -153,20 +142,38 @@ public class TerrainProfileHandler extends ActionHandler {
         try {
             Geometry geom = GeoJSONReader.toGeometry(route.getJSONObject("geometry"));
             if (!(geom.getGeometryType().equals("LineString"))) {
-                throw new ActionParamsException("Invalid input"
-                        + " - expected LineString geometry");
-            }
-            if (geom.getNumPoints() < 2) {
-                throw new ActionParamsException("Invalid input"
-                        + " - expected LineString with atleast two coordinates");
+                throw new ActionParamsException("Invalid input - expected LineString geometry");
             }
             if (geom.getNumPoints() > NUM_POINTS_MAX) {
-                throw new ActionParamsException("Invalid input"
-                        + " - too many coordinates, maximum is " + NUM_POINTS_MAX);
+                throw new ActionParamsException("Invalid input - too many coordinates, maximum is " + NUM_POINTS_MAX);
             }
             return geom;
         } catch (JSONException e) {
             throw new ActionParamsException("Invalid input - expected GeoJSON feature", e);
+        } catch (IllegalArgumentException e) {
+            throw new ActionParamsException("Invalid input - expected LineString with atleast two coordinates");
+        }
+    }
+
+    protected Geometry getReprojected(Geometry geom, String fromSrs, String toSrs) throws ActionException {
+        MathTransform transform = getTransform(fromSrs, toSrs);
+        try {
+            return JTS.transform(geom, transform);
+        } catch (TransformException e) {
+            throw new ActionException(e.getMessage(), e);
+        }
+    }
+
+    protected MathTransform getTransform(String fromSrs, String toSrs) throws ActionException {
+        CoordinateReferenceSystem fromCRS;
+        CoordinateReferenceSystem toCRS;
+        try {
+            fromCRS = CRS.decode(fromSrs);
+            toCRS = CRS.decode(toSrs);
+            boolean lenient = true; // allow for some error due to different datums
+            return CRS.findMathTransform(fromCRS, toCRS, lenient);
+        } catch (FactoryException e) {
+            throw new ActionParamsException("Invalid " + ActionConstants.PARAM_SRS);
         }
     }
 
@@ -194,22 +201,21 @@ public class TerrainProfileHandler extends ActionHandler {
         return 0;
     }
 
-    protected void writeResponse(ActionParameters params, List<DataPoint> dp) throws ActionException {
-
-        try {
-            CoordinateReferenceSystem dataCRS = CRS.decode("EPSG:3857");
-            CoordinateReferenceSystem serviceCRS = CRS.decode("EPSG:3067", true);
-            boolean lenient = true; // allow for some error due to different datums
-            MathTransform transform = CRS.findMathTransform(serviceCRS, dataCRS, lenient);
+    protected void writeResponse(ActionParameters params, List<DataPoint> dp, boolean reproject) throws ActionException {
+        if (reproject) {
+            String targetSRS = params.getHttpParam(ActionConstants.PARAM_SRS, DEFAULT_SRS);
+            MathTransform transform = getTransform(serviceSrs, targetSRS);
             GeometryFactory gf = new GeometryFactory();
-            for (DataPoint cur : dp) {
-                Geometry geom = gf.createPoint(new Coordinate(cur.getE(), cur.getN()));
-                geom = JTS.transform(geom, transform);
-                cur.setE(geom.getCoordinate().x);
-                cur.setN(geom.getCoordinate().y);
+            try {
+                for (DataPoint cur : dp) {
+                    Geometry geom = gf.createPoint(new Coordinate(cur.getE(), cur.getN()));
+                    geom = JTS.transform(geom, transform);
+                    cur.setE(geom.getCoordinate().x);
+                    cur.setN(geom.getCoordinate().y);
+                }
+            } catch (TransformException e) {
+                throw new ActionException(e.getMessage(), e);
             }
-        } catch (FactoryException | TransformException e) {
-            throw new ActionException(e.getMessage(), e);
         }
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (JsonGenerator json = om.getFactory().createGenerator(baos)) {

--- a/service-terrain-profile/src/main/java/fi/nls/paikkatietoikkuna/terrainprofile/TerrainProfileHandler.java
+++ b/service-terrain-profile/src/main/java/fi/nls/paikkatietoikkuna/terrainprofile/TerrainProfileHandler.java
@@ -114,7 +114,7 @@ public class TerrainProfileHandler extends ActionHandler {
         Geometry geom = getGeometry(route);
         try {
             CoordinateReferenceSystem dataCRS = CRS.decode("EPSG:3857");
-            CoordinateReferenceSystem serviceCRS = CRS.decode("EPSG:3067", true);
+            CoordinateReferenceSystem serviceCRS = CRS.decode("EPSG:3067");
             boolean lenient = true; // allow for some error due to different datums
             MathTransform transform = CRS.findMathTransform(dataCRS, serviceCRS, lenient);
             geom = JTS.transform(geom, transform);
@@ -130,7 +130,7 @@ public class TerrainProfileHandler extends ActionHandler {
         JSONObject properties = route.optJSONObject(JSON_PROPERTY_PROPERTIES);
         int numPoints = Math.min(getNumPoints(properties), NUM_POINTS_MAX);
         double scaleFactor = getScaleFactor(properties);
-        double[] points = new double[numPoints];
+        double[] points = new double[geom.getNumPoints() * 2];
         int ptIndex = -1;
         for (Coordinate coord : geom.getCoordinates()) {
             points[++ptIndex] = coord.x;

--- a/service-terrain-profile/src/test/java/fi/nls/paikkatietoikkuna/terrainprofile/TerrainProfileHandlerTest.java
+++ b/service-terrain-profile/src/test/java/fi/nls/paikkatietoikkuna/terrainprofile/TerrainProfileHandlerTest.java
@@ -179,8 +179,8 @@ public class TerrainProfileHandlerTest {
         params.setRequest(request);
         params.setResponse(response);
 
-        String endPoint = "http://avoindata.maanmittauslaitos.fi/geoserver/wcs";
-        String coverageId = "korkeusmalli_10m__korkeusmalli_10m";
+        String endPoint = "https://beta-karttakuva.maanmittauslaitos.fi/wcs/service/ows";
+        String coverageId = "korkeusmalli__korkeusmalli";
         TerrainProfileService tps = new TerrainProfileService(endPoint, coverageId);
         new TerrainProfileHandler(om, tps).handleAction(params);
     }


### PR DESCRIPTION
Provides projection support for terrain-profile action.

Action route now accepts param `srs` for sent geojson. Result will be reprojected too.
Service end point srs defaults to EPSG:3067. It can be chaned in ext-oskari.properties with key `terrain.profile.wcs.srs`.