### PR TITLE
Fix app names in 3D-migrations

### DIFF
--- a/server-extension/src/main/java/flyway/pti3d/V1_4__setup_3D_publishing.java
+++ b/server-extension/src/main/java/flyway/pti3d/V1_4__setup_3D_publishing.java
@@ -15,7 +15,7 @@ public class V1_4__setup_3D_publishing implements JdbcMigration {
 
     private static final String TEMPLATE_JSON = "paikkis-3D-publish-template.json";
     private static final String METADATA_TEMPLATE_KEY = "publishTemplateUuid";
-    private static final String APPLICATION_3D_NAME = "full-map-3D";
+    private static final String APPLICATION_3D_NAME = "geoportal-3D";
     
     private ViewService viewService;
 

--- a/server-extension/src/main/java/flyway/pti3d/V1_5__add_3857_to_coordinatetool.java
+++ b/server-extension/src/main/java/flyway/pti3d/V1_5__add_3857_to_coordinatetool.java
@@ -25,8 +25,8 @@ public class V1_5__add_3857_to_coordinatetool implements JdbcMigration {
 
     private static final Logger LOG = LogFactory.getLogger(V1_5__add_3857_to_coordinatetool.class);
     private static final String BUNDLE_NAME = "coordinatetool";
-    private static final String APPLICATION_3D_FULL = "full-map-3D";
-    private static final String APPLICATION_3D_PUBLISHED = "published-map-3D";
+    private static final String APPLICATION_3D_FULL = "geoportal-3D";
+    private static final String APPLICATION_3D_PUBLISHED = "embedded-3D";
     private static final String SUPPORTED_PROJECTIONS = "supportedProjections";
     private static final String EPSG_3857 = "EPSG:3857";
     private ViewService viewService = null;


### PR DESCRIPTION
The app names were changed in #116 and the 3d module wasn't working when enabled after migrations added in #116. This fixes the issue.