### PR TITLE
Add migration to remove camera controls 3d bundle from publish view

### DIFF
--- a/server-extension/src/main/java/flyway/pti3d/V1_7__remove_camera_controls_3d_bundle_from_publish_view.java
+++ b/server-extension/src/main/java/flyway/pti3d/V1_7__remove_camera_controls_3d_bundle_from_publish_view.java
@@ -1,0 +1,42 @@
+package flyway.pti3d;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+
+import fi.nls.oskari.util.FlywayHelper;
+
+public class V1_7__remove_camera_controls_3d_bundle_from_publish_view implements JdbcMigration {
+
+	private static final String BUNDLE_ID = "camera-controls-3d";
+
+	@Override
+	public void migrate(Connection connection) throws Exception {
+		final Long viewId = get3dPublishViewID(connection);
+		if (FlywayHelper.viewContainsBundle(connection, BUNDLE_ID, viewId)) {
+			FlywayHelper.removeBundleFromView(connection, BUNDLE_ID, viewId);
+		}
+	}
+
+	private static Long get3dPublishViewID(Connection connection) throws SQLException {
+		StringBuilder sql = new StringBuilder(
+				"SELECT id FROM portti_view where type='PUBLISH' AND application='embedded-3D'");
+
+		try (final PreparedStatement statement = connection.prepareStatement(sql.toString())) {
+			try (ResultSet rs = statement.executeQuery()) {
+				if(rs.next()) {
+					return rs.getLong("id");
+				} else {
+					/*
+					 *  ID should be always found but just in case return this instead of null 
+					 *  to prevent NullPointerExceptions in subsequent helper methods.
+					 */
+					return Long.MIN_VALUE;
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Remove camera controls 3D bundle from 3D publish view. Bundle was added to mentioned view in https://github.com/nls-oskari/kartta.paikkatietoikkuna.fi/pull/122 but further testing revealed that if mentioned bundle is added to publish view, camera controls from the bundle are always included in published map regardless of what user selects in publisher user interface.  With this change camera controls in mentioned bundle is included to published map if chosen to be included by user.