### PR TITLE
DimensionChange fix for 3d -> 2d

### DIFF
--- a/app-resources/src/main/java/flyway/pti3d/V1_8__setup_dimension_change_to_2d.java
+++ b/app-resources/src/main/java/flyway/pti3d/V1_8__setup_dimension_change_to_2d.java
@@ -1,0 +1,32 @@
+package flyway.pti3d;
+
+import fi.nls.oskari.domain.map.view.Bundle;
+import fi.nls.oskari.util.FlywayHelper;
+import fi.nls.oskari.util.JSONHelper;
+import org.flywaydb.core.api.migration.jdbc.JdbcMigration;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+
+public class V1_8__setup_dimension_change_to_2d implements JdbcMigration {
+
+    private static final String BUNDLE_NAME = "dimension-change";
+    private static final String APPLICATION_2D_NAME = "geoportal";
+    private static final String APPLICATION_3D_NAME = "geoportal-3D";
+
+    public void migrate(Connection connection) throws SQLException {
+        // with 2D application name gets default view's uuid if there is only on default view
+        String uuid = FlywayHelper3D.get3DViewUuid(connection, APPLICATION_2D_NAME);
+        final List<Long> viewIds = FlywayHelper.getUserAndDefaultViewIds(connection, APPLICATION_3D_NAME);
+
+        for (Long id : viewIds) {
+            if (!FlywayHelper.viewContainsBundle(connection, BUNDLE_NAME, id)) {
+                FlywayHelper.addBundleWithDefaults(connection, id, BUNDLE_NAME);
+            }
+            Bundle bundle = FlywayHelper.getBundleFromView(connection, BUNDLE_NAME, id);
+            bundle.setConfig(JSONHelper.createJSONObject("uuid", uuid).toString());
+            FlywayHelper.updateBundleInView(connection, bundle, id);
+        }
+    }
+}


### PR DESCRIPTION
Add default 2d view uuid to 3D views' dimension-change config. Without uuid dimension change loads default view. Fixes issue where user has 3d view as default view. 

Works if there is only one default 2d view. If there is more, then should change to get all default views (id and uuid) and check default view id from properties before returning uuid.

After:
https://github.com/oskariorg/oskari-server/pull/517
