### PR TITLE
Coordinatetool add kkj to supported projections

### DIFF
--- a/app-resources/src/main/java/flyway/pti/V3_0_4__coordinatetool_add_kkj.java
+++ b/app-resources/src/main/java/flyway/pti/V3_0_4__coordinatetool_add_kkj.java
@@ -1,0 +1,55 @@
+package flyway.pti;
+
+import fi.nls.oskari.domain.map.view.Bundle;
+import fi.nls.oskari.util.JSONHelper;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.oskari.helpers.AppSetupHelper;
+
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Adds NLSFI:kkj to coordinatetool supported projections to all default/user appsetups
+ */
+public class V3_0_4__coordinatetool_add_kkj extends BaseJavaMigration {
+    private static final String KKJ = "NLSFI:kkj";
+    private static final String ADD_BEFORE = "NLSFI:ykj";
+    private static final String BUNDLE = "coordinatetool";
+    private static final String SUPPORTED_EPSG = "supportedProjections";
+
+    public void migrate(Context context) throws Exception {
+        Connection connection = context.getConnection();
+        // embedded maps doesn't have transformations, migrate only default and user appsetups
+        List<Long> viewIds =  AppSetupHelper.getSetupsForUserAndDefaultType(connection);
+        for (Long id : viewIds) {
+            updateAppsetup(connection, id);
+        }
+    }
+    private void updateAppsetup(Connection connection, Long viewId) throws SQLException {
+        Bundle bundle =  AppSetupHelper.getAppBundle(connection, viewId, BUNDLE);
+        if (bundle == null) {
+            //skip
+            return;
+        }
+        JSONObject conf = bundle.getConfigJSON();
+        List<String> epsgs = JSONHelper.getArrayAsList(conf.optJSONArray(SUPPORTED_EPSG));
+        if (epsgs.isEmpty() || epsgs.contains(KKJ)) {
+            // skip
+            return;
+        }
+        int index = epsgs.indexOf(ADD_BEFORE);
+        if (index != -1) {
+            epsgs.add(index, KKJ);
+        } else {
+            epsgs.add(KKJ);
+        }
+        JSONHelper.put(conf, SUPPORTED_EPSG, new JSONArray(epsgs));
+        bundle.setConfig(conf.toString());
+        AppSetupHelper.updateAppBundle(connection, viewId, bundle);
+    }
+}

--- a/app-resources/src/main/resources/json/views/geoportal-3D.json
+++ b/app-resources/src/main/resources/json/views/geoportal-3D.json
@@ -158,6 +158,7 @@
           "EPSG:3857",
           "EPSG:3067",
           "NLSFI:etrs_gk",
+          "NLSFI:kkj",
           "NLSFI:ykj",
           "EPSG:4258",
           "LATLON:kkj",

--- a/app-resources/src/main/resources/json/views/geoportal.json
+++ b/app-resources/src/main/resources/json/views/geoportal.json
@@ -159,6 +159,7 @@
       "supportedProjections": [
         "EPSG:3067",
         "NLSFI:etrs_gk",
+        "NLSFI:kkj",
         "NLSFI:ykj",
         "EPSG:4258",
         "LATLON:kkj",


### PR DESCRIPTION
Add NLSFI:kkj to coordinatetool supported projections before NLSFI:ykj. Added also to view json. Oskari frontend has localization already for kkj.