### PR TITLE
Refactor LayerStatus

### DIFF
--- a/server-extension/src/main/java/fi/nls/layerstatus/LayerStatus.java
+++ b/server-extension/src/main/java/fi/nls/layerstatus/LayerStatus.java
@@ -1,5 +1,8 @@
 package fi.nls.layerstatus;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.json.JSONObject;
 
 public class LayerStatus {
@@ -8,7 +11,8 @@ public class LayerStatus {
     private long errors = 0;
     private long success = 0;
 
-    LayerStatus(String id) {
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    LayerStatus(@JsonProperty("id") String id) {
         this.id = id;
     }
 
@@ -37,6 +41,8 @@ public class LayerStatus {
     public long getSuccess() {
         return success;
     }
+    
+    @JsonIgnore
     public long getRequestCount() {
         return success + errors;
     }

--- a/server-extension/src/main/java/fi/nls/layerstatus/LayerStatus.java
+++ b/server-extension/src/main/java/fi/nls/layerstatus/LayerStatus.java
@@ -1,0 +1,31 @@
+package fi.nls.layerstatus;
+
+import org.json.JSONObject;
+
+public class LayerStatus {
+
+    private final String id;
+    private long errors = 0;
+    private long success = 0;
+
+    LayerStatus(String id, JSONObject data) {
+        this.id = id;
+        this.errors = data.optLong("errors");
+        this.success = data.optLong("success");
+    }
+    
+    public String getId() {
+        return id;
+    }
+
+    public long getErrors() {
+        return errors;
+    }
+
+    public long getSuccess() {
+        return success;
+    }
+    public long getRequestCount() {
+        return success + errors;
+    }
+}

--- a/server-extension/src/main/java/fi/nls/layerstatus/LayerStatus.java
+++ b/server-extension/src/main/java/fi/nls/layerstatus/LayerStatus.java
@@ -3,6 +3,7 @@ package fi.nls.layerstatus;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 public class LayerStatus {
@@ -45,5 +46,14 @@ public class LayerStatus {
     @JsonIgnore
     public long getRequestCount() {
         return success + errors;
+    }
+
+    @JsonIgnore
+    public JSONObject asJSON() throws JSONException {
+        JSONObject response = new JSONObject();
+        response.put("id", getId());
+        response.put("success", getSuccess());
+        response.put("errors", getErrors());
+        return response;
     }
 }

--- a/server-extension/src/main/java/fi/nls/layerstatus/LayerStatus.java
+++ b/server-extension/src/main/java/fi/nls/layerstatus/LayerStatus.java
@@ -8,12 +8,24 @@ public class LayerStatus {
     private long errors = 0;
     private long success = 0;
 
-    LayerStatus(String id, JSONObject data) {
+    LayerStatus(String id) {
         this.id = id;
+    }
+
+    LayerStatus(String id, JSONObject data) {
+        this(id);
         this.errors = data.optLong("errors");
         this.success = data.optLong("success");
     }
-    
+
+    public void addToSuccess(long amount) {
+        success += amount;
+    }
+
+    public void addToErrors(long amount) {
+        errors += amount;
+    }
+
     public String getId() {
         return id;
     }

--- a/server-extension/src/main/java/fi/nls/layerstatus/LayerStatusService.java
+++ b/server-extension/src/main/java/fi/nls/layerstatus/LayerStatusService.java
@@ -1,0 +1,83 @@
+package fi.nls.layerstatus;
+
+import fi.nls.oskari.cache.Cache;
+import fi.nls.oskari.cache.CacheManager;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.service.OskariComponent;
+import fi.nls.oskari.util.JSONHelper;
+import org.json.JSONObject;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class LayerStatusService extends OskariComponent {
+
+    private Logger log = LogFactory.getLogger("STATUS");
+    private Cache<JSONObject> cache;
+
+    public void init() {
+        cache = CacheManager.getCache(LayerStatusService.class.getName());
+        cache.setLimit(10000);
+        // should result in two weeks since the default is 30mins
+        cache.setExpiration(cache.getExpiration() * 48 * 14);
+    }
+
+    public List<LayerStatus> getStatuses() {
+        List<LayerStatus> list = cache.getKeys().stream()
+                .map(layerId -> new LayerStatus(layerId, cache.get(layerId)))
+                .collect(Collectors.toList());
+        return list;
+    }
+
+    public List<JSONObject> getMostErrors(int limit) {
+        List<JSONObject> mostErrors = getStatuses().stream()
+                .sorted(Comparator.comparingLong(LayerStatus::getErrors).reversed())
+                .limit(limit)
+                .map(layer -> {
+                    JSONObject o = new JSONObject();
+                    JSONHelper.putValue(o, "id", layer.getId());
+                    JSONHelper.putValue(o, "errors", layer.getErrors());
+                    JSONHelper.putValue(o, "success", layer.getSuccess());
+                    return o;
+                })
+                .collect(Collectors.toList());
+        return mostErrors;
+    }
+
+    public List<JSONObject> getMostUsed(int limit) {
+        List<JSONObject> mostSuccess = getStatuses().stream()
+                .sorted(Comparator.comparingLong(LayerStatus::getRequestCount).reversed())
+                .limit(limit)
+                .map(layer -> {
+                    JSONObject o = new JSONObject();
+                    JSONHelper.putValue(o, "id", layer.getId());
+                    JSONHelper.putValue(o, "errors", layer.getErrors());
+                    JSONHelper.putValue(o, "success", layer.getSuccess());
+                    return o;
+                })
+                .collect(Collectors.toList());
+        return mostSuccess;
+    }
+
+    // {801: {errors: 0, success: 73, stack: [], previous: "success"}}
+    public void saveStatus(JSONObject payload) {
+        payload.keys().forEachRemaining(layerId -> {
+            String id = (String) layerId;
+            JSONObject layerData = payload.optJSONObject(id);
+            layerData.remove("previous");
+            // write log to get stacks for error debugging
+            log.info(layerId, "-", layerData.toString());
+            // write to cache so we can examine combined error counts for all nodes
+            JSONObject value = cache.get(id);
+            if (value != null) {
+                long successCount = value.optLong("success", 0) + layerData.optLong("success", 0);
+                JSONHelper.putValue(layerData, "success", successCount);
+                long errorCount = value.optLong("errors", 0) + layerData.optLong("errors", 0);
+                JSONHelper.putValue(layerData, "errors", errorCount);
+            }
+            cache.put(id, layerData);
+        });
+    }
+}

--- a/server-extension/src/main/java/fi/nls/layerstatus/LayerStatusService.java
+++ b/server-extension/src/main/java/fi/nls/layerstatus/LayerStatusService.java
@@ -2,8 +2,7 @@ package fi.nls.layerstatus;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import fi.nls.oskari.cache.Cache;
-import fi.nls.oskari.cache.CacheManager;
+import fi.nls.oskari.annotation.Oskari;
 import fi.nls.oskari.cache.JedisManager;
 import fi.nls.oskari.log.LogFactory;
 import fi.nls.oskari.log.Logger;
@@ -17,6 +16,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@Oskari
 public class LayerStatusService extends OskariComponent {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/server-extension/src/main/java/fi/nls/layerstatus/LayerStatusService.java
+++ b/server-extension/src/main/java/fi/nls/layerstatus/LayerStatusService.java
@@ -91,7 +91,7 @@ public class LayerStatusService extends OskariComponent {
         try {
             LayerStatus status = getEntry(id);
             JSONObject response = status.asJSON();
-            response.put("stack", new JSONArray(getRawDataFromRedis(id)));
+            response.put("details", new JSONArray(getRawDataFromRedis(id)));
             return response;
         } catch (Exception ignored) {}
         return null;

--- a/server-extension/src/main/java/fi/nls/layerstatus/LayerStatusService.java
+++ b/server-extension/src/main/java/fi/nls/layerstatus/LayerStatusService.java
@@ -9,6 +9,7 @@ import fi.nls.oskari.log.Logger;
 import fi.nls.oskari.service.OskariComponent;
 import fi.nls.oskari.service.ServiceRuntimeException;
 import fi.nls.oskari.util.JSONHelper;
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.util.Comparator;
@@ -62,11 +63,18 @@ public class LayerStatusService extends OskariComponent {
         payload.keys().forEachRemaining(layerId -> {
             String id = (String) layerId;
             JSONObject layerData = payload.optJSONObject(id);
+            // we don't really care about the previous key as it's used by
+            //  frontend to detect state change between failure <> success
+            layerData.remove("previous");
+            long errorCount = layerData.optLong("errors", 0);
             updateToRedis(
                     id,
                     layerData.optLong("success", 0),
-                    layerData.optLong("errors", 0)
+                    errorCount
             );
+            if (errorCount != 0) {
+                saveStack(id, layerData);
+            }
             // write log to get stacks for error debugging
             log.info(layerId, "-", layerData.toString());
         });
@@ -79,6 +87,39 @@ public class LayerStatusService extends OskariComponent {
                 .collect(Collectors.toList());
     }
 
+    public JSONObject getDetails(String id) {
+        try {
+            LayerStatus status = getEntry(id);
+            JSONObject response = status.asJSON();
+            response.put("stack", new JSONArray(getRawDataFromRedis(id)));
+            return response;
+        } catch (Exception ignored) {}
+        return null;
+    }
+
+    private List<JSONObject> getRawDataFromRedis(String id) {
+        String redisKey = getRawDataKeyForRedis(id);
+        Set<String> keys = JedisManager.hkeys(redisKey);
+
+        return keys.stream()
+                .map(dataId -> getRawDataFromRedis(redisKey, dataId))
+                .filter(data -> data != null)
+                .collect(Collectors.toList());
+    }
+
+    private JSONObject getRawDataFromRedis(String redisKey, String rawDataId) {
+        String data = JedisManager.hget(redisKey, rawDataId);
+        try {
+            JSONObject value = new JSONObject(data);
+            // raw data id is System.currentTimeMillis() as string
+            value.put("time", Long.parseLong(rawDataId));
+            return value;
+        } catch (Exception ignored) {
+            log.warn("Unable to deserialize rawdata for key:", redisKey, "dataId:", rawDataId);
+        }
+        return null;
+    }
+
     private void updateToRedis(String id, long success, long errors) {
         // TODO: should use https://redis.io/commands/hincrby instead or save to postgres?
         LayerStatus status = getEntry(id);
@@ -87,6 +128,21 @@ public class LayerStatusService extends OskariComponent {
         JedisManager.hset(REDIS_KEY, id, writeAsJSON(status));
         // TODO: bake id into key and use date string as field (current id) to get time dimension?
         // Set<String> keys = JedisManager.hkeys(REDIS_KEY)
+    }
+
+    private void saveStack(String id, JSONObject dataFromUser) {
+        JSONArray stack = dataFromUser.optJSONArray("stack");
+        if (stack == null || stack.length() == 0) {
+            return;
+        }
+        JedisManager.hset(getRawDataKeyForRedis(id), "" + System.currentTimeMillis(), dataFromUser.toString());
+        // we could use list but JedisManager only has getters for list that modify it
+        // If we don't move this to postgres then we might want to add both the increment method and list getters to JedisManager
+        // JedisManager.pushToList(getRawDataKeyForRedis(id), value.toString());
+    }
+
+    private String getRawDataKeyForRedis(String id) {
+        return REDIS_KEY + "_" + id + "_raw";
     }
 
     private LayerStatus getEntry(String id) {

--- a/server-extension/src/main/java/fi/nls/paikkis/control/LayerStatusHandler.java
+++ b/server-extension/src/main/java/fi/nls/paikkis/control/LayerStatusHandler.java
@@ -1,116 +1,42 @@
 package fi.nls.paikkis.control;
 
+import fi.nls.layerstatus.LayerStatusService;
 import fi.nls.oskari.annotation.OskariActionRoute;
-import fi.nls.oskari.cache.Cache;
-import fi.nls.oskari.cache.CacheManager;
 import fi.nls.oskari.control.ActionDeniedException;
 import fi.nls.oskari.control.ActionParameters;
 import fi.nls.oskari.control.ActionParamsException;
 import fi.nls.oskari.control.RestActionHandler;
-import fi.nls.oskari.log.LogFactory;
-import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.ResponseHelper;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import java.util.Comparator;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 @OskariActionRoute("LayerStatus")
 public class LayerStatusHandler extends RestActionHandler {
 
-    private Logger log = LogFactory.getLogger("STATUS");
-    private Cache<JSONObject> cache;
-
-    private class Layer {
-        String id;
-        long errors = 0;
-        long success = 0;
-
-        Layer(String id, JSONObject data) {
-            this.id = id;
-            this.errors = data.optLong("errors");
-            this.success = data.optLong("success");
-        }
-
-        public long getErrors() {
-            return errors;
-        }
-
-        public long getSuccess() {
-            return success;
-        }
-    }
-
-    public void init() {
-        cache = CacheManager.getCache(LayerStatusHandler.class.getName());
-        cache.setLimit(10000);
-        // should result in two weeks since the default is 30mins
-        cache.setExpiration(cache.getExpiration() * 48 * 14);
+    private LayerStatusService getService() {
+        return OskariComponentManager.getComponentOfType(LayerStatusService.class);
     }
 
     public void handleGet(ActionParameters params) throws ActionDeniedException {
         params.requireAdminUser();
+
         int limit = params.getHttpParam("limit", 20);
+        LayerStatusService service = getService();
+
         final JSONObject response = new JSONObject();
-
-        List<Layer> list = cache.getKeys().stream()
-            .map(layerId -> new Layer(layerId, cache.get(layerId)))
-            .collect(Collectors.toList());
-
-        JSONHelper.putValue(response, "layerCount", list.size());
-
-        List<JSONObject> mostErrors = list.stream()
-                .sorted(Comparator.comparingLong(Layer::getErrors).reversed())
-                .limit(limit)
-                .map(layer -> {
-                    JSONObject o = new JSONObject();
-                    JSONHelper.putValue(o, "id", layer.id);
-                    JSONHelper.putValue(o, "errors", layer.errors);
-                    JSONHelper.putValue(o, "success", layer.success);
-                    return o;
-                })
-                .collect(Collectors.toList());
-        JSONHelper.putValue(response, "errorsTop", new JSONArray(mostErrors));
-
-        List<JSONObject> mostSuccess = list.stream()
-                .sorted(Comparator.comparingLong(Layer::getSuccess).reversed())
-                .limit(limit)
-                .map(layer -> {
-                    JSONObject o = new JSONObject();
-                    JSONHelper.putValue(o, "id", layer.id);
-                    JSONHelper.putValue(o, "errors", layer.errors);
-                    JSONHelper.putValue(o, "success", layer.success);
-                    return o;
-                })
-                .collect(Collectors.toList());
-        JSONHelper.putValue(response, "successTop", new JSONArray(mostSuccess));
+        JSONHelper.putValue(response, "layerCount", service.getStatuses().size());
+        JSONHelper.putValue(response, "errorsTop", new JSONArray(service.getMostErrors(limit)));
+        JSONHelper.putValue(response, "mostUsed", new JSONArray(service.getMostUsed(limit)));
 
         ResponseHelper.writeResponse(params, response);
     }
 
     @Override
     public void handlePost(ActionParameters params) throws ActionParamsException {
-        // {801: {errors: 0, success: 73, stack: [], previous: "success"}}
         JSONObject payload = params.getPayLoadJSON();
-        payload.keys().forEachRemaining(layerId -> {
-            String id = (String) layerId;
-            JSONObject layerData = payload.optJSONObject(id);
-            layerData.remove("previous");
-            // write log to get stacks for error debugging
-            log.info(layerId, "-", layerData.toString());
-            // write to cache so we can examine combined error counts for all nodes
-            JSONObject value = cache.get(id);
-            if (value != null) {
-                long successCount = value.optLong("success", 0) + layerData.optLong("success", 0);
-                JSONHelper.putValue(layerData, "success", successCount);
-                long errorCount = value.optLong("errors", 0) + layerData.optLong("errors", 0);
-                JSONHelper.putValue(layerData, "errors", errorCount);
-            }
-            cache.put(id, layerData);
-        });
+        LayerStatusService service = getService();
+        service.saveStatus(payload);
     }
 }


### PR DESCRIPTION
Now data is saved to Redis to make it "global" in a cluster. We could use better Redis commands to do this but since this data might end up in postgres this was implemented in a way that didn't require changes to oskari-server. 

Admins can query a list of layers that have seen usage:
`/action?action_route=LayerStatus`

Format: 
```
{
    [layer id]: {
        success: xx,
        errors: xx
    },
    ...
}
```
Example response:
```
{
    "1373": {
        "success": 113,
        "errors": 0
    },
    "1197": {
        "success": 0,
        "errors": 47
    },
    "1171": {
        "success": 9,
        "errors": 0
    },
    "1701": {
        "success": 16,
        "errors": 0
    },
    "1203": {
        "success": 0,
        "errors": 11
    },
    "775": {
        "success": 0,
        "errors": 6
    },
    "1167": {
        "success": 9,
        "errors": 0
    },
    "414": {
        "success": 99,
        "errors": 0
    },
    "1166": {
        "success": 16,
        "errors": 0
    },
    "801": {
        "success": 521,
        "errors": 0
    },
    "417": {
        "success": 20,
        "errors": 0
    },
    "2619": {
        "success": 16,
        "errors": 0
    },
    "829": {
        "success": 16,
        "errors": 0
    }
}
```
And query details about layers when there have been problems with it:
`/action?action_route=LayerStatus&id=[layer id]`

Format:
```
{
    id: [layer id],
    success: xx,
    errors: xx,
    details: [...0-n occurances with map states when errors happened... ]
}
```
Example response:
```
{
    "id": "1203",
    "success": 0,
    "errors": 11,
    "details": [
        {
            "time": 1622100689176,
            "success": 0,
            "errors": 11,
            "stack": [
                {
                    "x": 263805.06451537774,
                    "layers": [
                        801,
                        1203
                    ],
                    "y": 7192617.012903076,
                    "z": 0,
                    "state": "error"
                }
            ]
        }
    ]
}
```