### PR TITLE
Enable layer status removal

### DIFF
--- a/server-extension/src/main/java/fi/nls/layerstatus/LayerStatusService.java
+++ b/server-extension/src/main/java/fi/nls/layerstatus/LayerStatusService.java
@@ -97,6 +97,15 @@ public class LayerStatusService extends OskariComponent {
         return null;
     }
 
+    public void removeLayerStatus(String id) {
+        JedisManager.hdel(REDIS_KEY, id);
+    }
+
+    public void removeLayerRawData(String id, String dataId) {
+        String redisKey = getRawDataKeyForRedis(id);
+        JedisManager.hdel(redisKey, dataId);
+    }
+
     private List<JSONObject> getRawDataFromRedis(String id) {
         String redisKey = getRawDataKeyForRedis(id);
         Set<String> keys = JedisManager.hkeys(redisKey);

--- a/server-extension/src/main/java/fi/nls/layerstatus/LayerStatusService.java
+++ b/server-extension/src/main/java/fi/nls/layerstatus/LayerStatusService.java
@@ -147,6 +147,9 @@ public class LayerStatusService extends OskariComponent {
         JedisManager.hset(getRawDataKeyForRedis(id), "" + System.currentTimeMillis(), dataFromUser.toString());
         // we could use list but JedisManager only has getters for list that modify it
         // If we don't move this to postgres then we might want to add both the increment method and list getters to JedisManager
+        //  Note! increment added in https://github.com/oskariorg/oskari-server/pull/729
+        //  List handling seems a bit unwieldy via Redis if we would want to remove an item from the list with other than l/rpop()
+        //    so I would rather do it with postgres if we need that
         // JedisManager.pushToList(getRawDataKeyForRedis(id), value.toString());
     }
 

--- a/server-extension/src/main/java/fi/nls/paikkis/control/LayerStatusHandler.java
+++ b/server-extension/src/main/java/fi/nls/paikkis/control/LayerStatusHandler.java
@@ -2,10 +2,7 @@ package fi.nls.paikkis.control;
 
 import fi.nls.layerstatus.LayerStatusService;
 import fi.nls.oskari.annotation.OskariActionRoute;
-import fi.nls.oskari.control.ActionDeniedException;
-import fi.nls.oskari.control.ActionParameters;
-import fi.nls.oskari.control.ActionParamsException;
-import fi.nls.oskari.control.RestActionHandler;
+import fi.nls.oskari.control.*;
 import fi.nls.oskari.service.OskariComponentManager;
 import fi.nls.oskari.util.JSONHelper;
 import fi.nls.oskari.util.ResponseHelper;
@@ -49,5 +46,18 @@ public class LayerStatusHandler extends RestActionHandler {
         JSONObject payload = params.getPayLoadJSON();
         LayerStatusService service = getService();
         service.saveStatus(payload);
+    }
+
+    @Override
+    public void handleDelete(ActionParameters params) throws ActionException {
+        params.requireAdminUser();
+        String layerId = params.getRequiredParam("id");
+        String dataId = params.getHttpParam("dataId");
+        if (dataId == null) {
+            getService().removeLayerStatus(layerId);
+        } else {
+            getService().removeLayerRawData(layerId, dataId);
+        }
+        ResponseHelper.writeResponse(params, "OK");
     }
 }


### PR DESCRIPTION
Adds a way to remove data from LayerStatus tracking. So we can create an UI control for admin to click error report as "handled" removing it from the list. Requires oskariorg/oskari-server#729 in Maven repo for compilation.