### PR TITLE
Remove scale limits from user generated content

### DIFF
--- a/app-resources/src/main/resources/flyway/pti/V3_0_9__remove_scalelimit_from_usercontent.sql
+++ b/app-resources/src/main/resources/flyway/pti/V3_0_9__remove_scalelimit_from_usercontent.sql
@@ -1,0 +1,5 @@
+UPDATE oskari_maplayer
+    SET minscale=-1, maxscale=-1
+where
+    internal = true
+    and name in ('oskari:my_places', 'oskari:vuser_layer_data', 'oskari:analysis_data');


### PR DESCRIPTION
For some reason they were restricted in Paikkatietoikkuna and the restriction is no longer wanted.