### PR TITLE
Give localized error messages instead of debug info as error handling when loading articles

### DIFF
--- a/server-extension/src/main/java/fi/nls/paikkis/control/GetArticlesByTagHandler.java
+++ b/server-extension/src/main/java/fi/nls/paikkis/control/GetArticlesByTagHandler.java
@@ -114,12 +114,16 @@ public class GetArticlesByTagHandler extends ActionHandler {
         // Change any dummy article to a localized error message:
         for (int i = 0; i < articles.length(); i++) {
             JSONObject art = articles.optJSONObject(i);
-            if (art == null || !art.optBoolean(KEY_DUMMY)) {
+            if (art == null) {
                 continue;
             }
-            String debugInfo = art.optString(KEY_BODY);
-            JSONHelper.putValue(art, KEY_BODY, errorMsg.getOrDefault(params.getLocale().getLanguage(), ""));
-            JSONHelper.putValue(art, "debugInfo", debugInfo);
+            JSONObject content = art.optJSONObject(KEY_CONTENT);
+            if (content == null || !content.optBoolean(KEY_DUMMY)) {
+                continue;
+            }
+            String debugInfo = content.optString(KEY_BODY);
+            JSONHelper.putValue(content, KEY_BODY, errorMsg.getOrDefault(params.getLocale().getLanguage(), ""));
+            JSONHelper.putValue(content, "debugInfo", debugInfo);
         }
 
         final JSONObject response = new JSONObject();


### PR DESCRIPTION
Quick'n'dirty fix for paikkatietoikkuna specific handler for article content. Instead of the user getting a text in the UI for saying:
`[body from GetArticlesByTag action route with tags: 'ohje_karttaikkuna']` they now get `Failed to load user guide.`.