### PR TITLE
Remove parts of PXWeb metadata so it ages better

### DIFF
--- a/scripts/pxweb/pxweb_metadata_tk.json
+++ b/scripts/pxweb/pxweb_metadata_tk.json
@@ -9,11 +9,8 @@
     },
     "decimalCount": null,
     "timerange": {
-      "start": "FIRST DATA",
-      "end": "LAST DATA"
-    },
-    "updated": "LAST-UPDATE",
-    "nextUpdate": "NEXT-UPDATE"
+      "start": "FIRST DATA"
+    }
   },
   {
     "code": "M408",
@@ -26,11 +23,8 @@
     "valueType": "percentage",
     "decimalCount": 1,
     "timerange": {
-      "start": "1987",
-      "end": "2015"
-    },
-    "updated": "1.4.2016",
-    "nextUpdate": "29.3.2017"
+      "start": "1987"
+    }
   },
   {
     "code": "M411",
@@ -43,11 +37,8 @@
     "valueType": "count",
     "decimalCount": 0,
     "timerange": {
-      "start": "1987",
-      "end": "2015"
-    },
-    "updated": "1.4.2016",
-    "nextUpdate": "29.3.2017"
+      "start": "1987"
+    }
   },
   {
     "code": "M476",
@@ -60,11 +51,8 @@
     "valueType": "relative change",
     "decimalCount": 1,
     "timerange": {
-      "start": "1998",
-      "end": "2015"
-    },
-    "updated": "1.4.2016",
-    "nextUpdate": "29.3.2017"
+      "start": "1998"
+    }
   },
   {
     "code": "M391",
@@ -77,11 +65,8 @@
     "valueType": "percentage",
     "decimalCount": 1,
     "timerange": {
-      "start": "1987",
-      "end": "2015"
-    },
-    "updated": "1.4.2016",
-    "nextUpdate": "29.3.2017"
+      "start": "1987"
+    }
   },
   {
     "code": "M421",
@@ -94,11 +79,8 @@
     "valueType": "percentage",
     "decimalCount": 1,
     "timerange": {
-      "start": "1987",
-      "end": "2015"
-    },
-    "updated": "1.4.2016",
-    "nextUpdate": "29.3.2017"
+      "start": "1987"
+    }
   },
   {
     "code": "M478",
@@ -111,11 +93,8 @@
     "valueType": "percentage",
     "decimalCount": 1,
     "timerange": {
-      "start": "1987",
-      "end": "2015"
-    },
-    "updated": "1.4.2016",
-    "nextUpdate": "29.3.2017"
+      "start": "1987"
+    }
   },
   {
     "code": "M404",
@@ -128,11 +107,8 @@
     "valueType": "percentage",
     "decimalCount": 1,
     "timerange": {
-      "start": "1987",
-      "end": "2015"
-    },
-    "updated": "1.4.2016",
-    "nextUpdate": "29.3.2017"
+      "start": "1987"
+    }
   },
   {
     "code": "M410",
@@ -145,11 +121,8 @@
     "valueType": "percentage",
     "decimalCount": 1,
     "timerange": {
-      "start": "1987",
-      "end": "2015"
-    },
-    "updated": "1.4.2016",
-    "nextUpdate": "29.3.2017"
+      "start": "1987"
+    }
   },
   {
     "code": "M303",
@@ -162,11 +135,8 @@
     "valueType": "split",
     "decimalCount": 0,
     "timerange": {
-      "start": "2005",
-      "end": "2015"
-    },
-    "updated": "14.4.2016",
-    "nextUpdate": "11.4.2017"
+      "start": "2005"
+    }
   },
   {
     "code": "M297",
@@ -179,11 +149,8 @@
     "valueType": "split",
     "decimalCount": 0,
     "timerange": {
-      "start": "2005",
-      "end": "2015"
-    },
-    "updated": "17.5.2016",
-    "nextUpdate": "17.5.2017"
+      "start": "2005"
+    }
   },
   {
     "code": "M302",
@@ -196,11 +163,8 @@
     "valueType": "count",
     "decimalCount": 0,
     "timerange": {
-      "start": "2005",
-      "end": "2015"
-    },
-    "updated": "30.5.2016",
-    "nextUpdate": "26.5.2017"
+      "start": "2005"
+    }
   },
   {
     "code": "M44",
@@ -213,11 +177,8 @@
     "valueType": "count",
     "decimalCount": 0,
     "timerange": {
-      "start": "2005",
-      "end": "2015"
-    },
-    "updated": "24.5.2016",
-    "nextUpdate": "22.5.2017"
+      "start": "2005"
+    }
   },
   {
     "code": "M62",
@@ -230,11 +191,8 @@
     "valueType": "percentage",
     "decimalCount": 1,
     "timerange": {
-      "start": "2005",
-      "end": "2015"
-    },
-    "updated": "24.5.2016",
-    "nextUpdate": "22.5.2017"
+      "start": "2005"
+    }
   },
   {
     "code": "M70",
@@ -247,11 +205,8 @@
     "valueType": "percentage",
     "decimalCount": 1,
     "timerange": {
-      "start": "2005",
-      "end": "2015"
-    },
-    "updated": "24.5.2016",
-    "nextUpdate": "22.5.2017"
+      "start": "2005"
+    }
   },
   {
     "code": "M488",
@@ -264,11 +219,8 @@
     "valueType": "percentage",
     "decimalCount": 1,
     "timerange": {
-      "start": "1987",
-      "end": "2015"
-    },
-    "updated": "3.11.2016",
-    "nextUpdate": "2.11.2017"
+      "start": "1987"
+    }
   },
   {
     "code": "M486",
@@ -281,11 +233,8 @@
     "valueType": "percentage",
     "decimalCount": 1,
     "timerange": {
-      "start": "1987",
-      "end": "2015"
-    },
-    "updated": "3.11.2016",
-    "nextUpdate": "2.11.2017"
+      "start": "1987"
+    }
   },
   {
     "code": "M137",
@@ -298,11 +247,8 @@
     "valueType": "count",
     "decimalCount": 0,
     "timerange": {
-      "start": "1987",
-      "end": "2014"
-    },
-    "updated": "9.12.2016",
-    "nextUpdate": "17.2.2017"
+      "start": "1987"
+    }
   },
   {
     "code": "M140",
@@ -315,11 +261,8 @@
     "valueType": "percentage",
     "decimalCount": 1,
     "timerange": {
-      "start": "1987",
-      "end": "2014"
-    },
-    "updated": "9.12.2016",
-    "nextUpdate": "17.2.2017"
+      "start": "1987"
+    }
   },
   {
     "code": "M130",
@@ -332,11 +275,8 @@
     "valueType": "percentage",
     "decimalCount": 1,
     "timerange": {
-      "start": "1987",
-      "end": "2014"
-    },
-    "updated": "28.9.2016",
-    "nextUpdate": "27.9.2017"
+      "start": "1987"
+    }
   },
   {
     "code": "M162",
@@ -349,11 +289,8 @@
     "valueType": "percentage",
     "decimalCount": 1,
     "timerange": {
-      "start": "1987",
-      "end": "2014"
-    },
-    "updated": "9.12.2016",
-    "nextUpdate": "17.2.2017"
+      "start": "1987"
+    }
   },
   {
     "code": "M78",
@@ -366,11 +303,8 @@
     "valueType": "percentage",
     "decimalCount": 1,
     "timerange": {
-      "start": "1987",
-      "end": "2014"
-    },
-    "updated": "9.12.2016",
-    "nextUpdate": "17.2.2017"
+      "start": "1987"
+    }
   },
   {
     "code": "M485",
@@ -383,11 +317,8 @@
     "valueType": "ratio",
     "decimalCount": 1,
     "timerange": {
-      "start": "1987",
-      "end": "2014"
-    },
-    "updated": "9.12.2016",
-    "nextUpdate": "17.2.2017"
+      "start": "1987"
+    }
   },
   {
     "code": "M152",
@@ -400,11 +331,8 @@
     "valueType": "count",
     "decimalCount": 0,
     "timerange": {
-      "start": "1987",
-      "end": "2014"
-    },
-    "updated": "28.9.2016",
-    "nextUpdate": "27.9.2017"
+      "start": "1987"
+    }
   },
   {
     "code": "M72",
@@ -417,11 +345,8 @@
     "valueType": "percentage",
     "decimalCount": 1,
     "timerange": {
-      "start": "2007",
-      "end": "2014"
-    },
-    "updated": "28.9.2016",
-    "nextUpdate": "27.9.2017"
+      "start": "2007"
+    }
   },
   {
     "code": "M84",
@@ -434,11 +359,8 @@
     "valueType": "percentage",
     "decimalCount": 1,
     "timerange": {
-      "start": "2007",
-      "end": "2014"
-    },
-    "updated": "28.9.2016",
-    "nextUpdate": "27.9.2017"
+      "start": "2007"
+    }
   },
   {
     "code": "M106",
@@ -451,11 +373,8 @@
     "valueType": "percentage",
     "decimalCount": 1,
     "timerange": {
-      "start": "2007",
-      "end": "2014"
-    },
-    "updated": "28.9.2016",
-    "nextUpdate": "27.9.2017"
+      "start": "2007"
+    }
   },
   {
     "code": "M499",
@@ -465,11 +384,8 @@
     "valueType": "ratio",
     "decimalCount": 1,
     "timerange": {
-      "start": "2008",
-      "end": "2014"
-    },
-    "updated": "4.11.2016",
-    "nextUpdate": "2.6.2017"
+      "start": "2008"
+    }
   },
   {
     "code": "M496",
@@ -479,11 +395,8 @@
     "valueType": "ratio",
     "decimalCount": 1,
     "timerange": {
-      "start": "2008",
-      "end": "2014"
-    },
-    "updated": "4.11.2016",
-    "nextUpdate": "2.6.2017"
+      "start": "2008"
+    }
   },
   {
     "code": "M495",
@@ -493,10 +406,7 @@
     "valueType": "ratio",
     "decimalCount": 1,
     "timerange": {
-      "start": "2008",
-      "end": "2014"
-    },
-    "updated": "4.11.2016",
-    "nextUpdate": "2.6.2017"
+      "start": "2008"
+    }
   }
 ]

--- a/scripts/pxweb/transform_metadata.js
+++ b/scripts/pxweb/transform_metadata.js
@@ -49,14 +49,14 @@ const jsonItems = rows.map(row => {
         decimalCount: Number(cols[12]),
         timerange: {
             start: cols[8],
-            end: cols[9]
+            // - commented out since manually updated/end: cols[9]
         },
-        updated: cols[6],
-        nextUpdate: cols[7]
-//        lyhenne: cols[3],
-//        labels: cols[4] ? cols[4].split(',').map(l => l.trim()) : [],
-//        prio: Number(cols[5]),
-//        regionsets: cols[15] ? cols[15].split(',').map(l => l.trim()): []
+        // - commented out since manually updated/updated: cols[6],
+        // - commented out since manually updated/nextUpdate: cols[7]
+        // - commented out since not used/lyhenne: cols[3],
+        // - commented out since not used/labels: cols[4] ? cols[4].split(',').map(l => l.trim()) : [],
+        // - commented out since not used/prio: Number(cols[5]),
+        // - commented out since not used/regionsets: cols[15] ? cols[15].split(',').map(l => l.trim()): []
     }
 })
 .filter(item => !!item)


### PR DESCRIPTION
Since metadata is currently updated manually (not provided by service) we don't want old dates to be part of the metadata.