### PR TITLE
Update nls-search service package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <oskari.version>2.7.0-SNAPSHOT</oskari.version>
-        <nls.search.version>3.6.3</nls.search.version>
+        <nls.search.version>3.7.0</nls.search.version>
         <nls.proj.version>1.2</nls.proj.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Code that was no longer used was removed from the new version.