### PR TITLE
Fix locales for 2 broken region sets

### DIFF
--- a/app-resources/src/main/resources/flyway/ptistats/V1_43__fix_statslayer_locale.sql
+++ b/app-resources/src/main/resources/flyway/ptistats/V1_43__fix_statslayer_locale.sql
@@ -1,0 +1,8 @@
+
+UPDATE oskari_maplayer
+SET locale = '{"fi": {"name": "Pääkaupunkiseudun pienaluejako"},"en": {"name": "Helsinki Region Small Areas"}, "sv": {"name": "Helsingforsregionens småområden"}}'
+WHERE name = 'seutukartta:Seutu_pienalueet';
+
+UPDATE oskari_maplayer
+SET locale = '{"fi": {"name": "Pääkaupunkiseudun suuraluejako"},"en": {"name": "Helsinki Region Major Areas"}, "sv": {"name": "Helsingforsregionens storområden"}}'
+WHERE name = 'seutukartta:Seutu_suuralueet';


### PR DESCRIPTION
There was a comma missing in previous migration -> invalid JSON -> names were wiped.