### PR TITLE
add flyways

### DIFF
--- a/app-resources/src/main/resources/flyway/ptistats/V1_44__update_tilastokeskus_dataprovider.sql
+++ b/app-resources/src/main/resources/flyway/ptistats/V1_44__update_tilastokeskus_dataprovider.sql
@@ -1,0 +1,4 @@
+
+UPDATE oskari_statistical_datasource
+SET locale = '{"fi":{"name":"Tilastokeskus - Kuntien avainluvut 2020"},"sv":{"name":"Statistikcentralen - Kommunernas nyckeltal 2020"},"en":{"name":"Statistics Finland - Municipal key figures 2020"}}'
+WHERE locale LIKE '%Tilastokeskus%';

--- a/app-resources/src/main/resources/flyway/ptistats/V1_44__update_tilastokeskus_dataprovider.sql
+++ b/app-resources/src/main/resources/flyway/ptistats/V1_44__update_tilastokeskus_dataprovider.sql
@@ -1,4 +1,19 @@
 
 UPDATE oskari_statistical_datasource
-SET locale = '{"fi":{"name":"Tilastokeskus - Kuntien avainluvut 2020"},"sv":{"name":"Statistikcentralen - Kommunernas nyckeltal 2020"},"en":{"name":"Statistics Finland - Municipal key figures 2020"}}'
+SET locale = '{"fi":{"name":"Tilastokeskus - Kuntien avainluvut 2021 aluejaolla"},"sv":{"name":"Statistikcentralen - Kommunernas nyckeltal enligt områdesindelningen år 2021"},"en":{"name":"Statistics Finland - Municipal key figures with the 2021 regional division"}}',
+config='{
+	"url": "https://statfin.stat.fi/pxweb/api/v1/{language}/Kuntien_avainluvut/2021/kuntien_avainluvut_2021_aikasarja.px",
+	"info": {
+		"url": "http://www.tilastokeskus.fi"
+	},
+	"metadataFile": "/tilastokeskus_pxweb_metadata.json",
+	"regionKey": "Alue 2021",
+	"indicatorKey": "Tiedot",
+  "hints" : {
+    "dimensions" : [ {
+      "id" : "Vuosi",
+      "sort" : "DESC"
+    }]
+  }
+}'
 WHERE locale LIKE '%Tilastokeskus%';

--- a/app-resources/src/main/resources/flyway/ptistats/V1_45__update_helsinki_dataprovider.sql
+++ b/app-resources/src/main/resources/flyway/ptistats/V1_45__update_helsinki_dataprovider.sql
@@ -1,0 +1,5 @@
+
+-- Update API url for "PxWEB on City of Helsinki"
+UPDATE oskari_statistical_datasource
+SET config = '{"url":"https://stat.hel.fi/api/v1/fi/Aluesarjat","info":{"url":"https://stat.hel.fi"},"regionKey":"Alue","ignoredVariables":["Alue"]}'
+WHERE locale LIKE '%City of Helsinki%';


### PR DESCRIPTION
Not sure if Statistics Finland - Municipal key figures url and year should be updated also.

https://api.aluesarjat.fi/api/v1/fi/Helsingin%20seudun%20tilastot/P%C3%A4%C3%A4kaupunkiseutu%20alueittain is redirected to: https://stat.hel.fi/helsingin-tilastotietokannat/
Not sure if https://stat.hel.fi/api/v1/fi/Aluesarjat contains same indicators that old one (maybe contains more).