### PR TITLE
Bump search version to fix nearest address

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <oskari.version>2.10.0-SNAPSHOT</oskari.version>
-        <nls.search.version>4.0</nls.search.version>
+        <nls.search.version>4.1</nls.search.version>
         <nls.proj.version>1.2</nls.proj.version>
         <nls.terrain-profile.version>1.2</nls.terrain-profile.version>
 


### PR DESCRIPTION
In 4.1 the nearest address search uses NLS Geocoding service as backing service instead of the maasto wfs API that was shut down.

Config change:
```
# Remove:
- search.channel.NLS_NEAREST_FEATURE_CHANNEL.service.url=https://ws.nls.fi/maasto/nearestfeature
- search.channel.NLS_NEAREST_FEATURE_CHANNEL.service.user=[user]
- search.channel.NLS_NEAREST_FEATURE_CHANNEL.service.pass=[pass]
# Add:
+ search.channel.NLS_NEAREST_FEATURE_CHANNEL.APIkey=[same api key as for geocoding service]
```