### PR TITLE
Enable dummy login for dev env

### DIFF
--- a/server-extension/src/main/java/fi/nls/oskari/spring/security/preauth/HeaderAuthenticationDetails.java
+++ b/server-extension/src/main/java/fi/nls/oskari/spring/security/preauth/HeaderAuthenticationDetails.java
@@ -1,6 +1,7 @@
 package fi.nls.oskari.spring.security.preauth;
 
 import fi.nls.oskari.domain.User;
+import fi.nls.oskari.util.PropertyUtil;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.authority.GrantedAuthoritiesContainer;
@@ -18,14 +19,31 @@ public class HeaderAuthenticationDetails extends WebAuthenticationDetails
 
     public HeaderAuthenticationDetails(HttpServletRequest request, String headerPrefix) {
         super(request);
-        // offloaded to helper in case WebAuthenticationDetails is saved to session
-        this.user = UserDetailsHelper.parseUserFromHeaders(request, headerPrefix);
+        boolean devLogin = isDevEnv();
+        if (devLogin) {
+            this.user = generateDevUser();
+        } else {
+            // offloaded to helper in case WebAuthenticationDetails is saved to session
+            this.user = UserDetailsHelper.parseUserFromHeaders(request, headerPrefix);
+        }
     }
+
 
     public User getUser() {
         return this.user;
     }
 
+    public static boolean isDevEnv() {
+        return PropertyUtil.getOptional("useDevLogin", false);
+    }
+    private User generateDevUser() {
+        User user = new User();
+        user.setEmail(PropertyUtil.get("useDevLogin.email", "dev@oskari.org"));
+        user.setFirstname(PropertyUtil.get("useDevLogin.firstname", "dev"));
+        user.setLastname(PropertyUtil.get("useDevLogin.lastname", "oskari"));
+        user.setScreenname(PropertyUtil.get("useDevLogin.screenname", "dev"));
+        return user;
+    }
     @Override
     public Collection<? extends GrantedAuthority> getGrantedAuthorities() {
         return this.grantedAuthorities;

--- a/server-extension/src/main/java/fi/nls/oskari/spring/security/preauth/OskariPreAuthenticationSecurityConfig.java
+++ b/server-extension/src/main/java/fi/nls/oskari/spring/security/preauth/OskariPreAuthenticationSecurityConfig.java
@@ -42,12 +42,12 @@ public class OskariPreAuthenticationSecurityConfig extends WebSecurityConfigurer
         filter.setPrincipalRequestHeader(PropertyUtil.get("oskari.preauth.username.header", "auth-email"));
 
         HeaderAuthenticationDetailsSource headerAuthenticationDetailsSource = new HeaderAuthenticationDetailsSource();
-
-        filter.setExceptionIfHeaderMissing(true);
+        boolean isDevEnv = HeaderAuthenticationDetails.isDevEnv();
+        filter.setExceptionIfHeaderMissing(!isDevEnv);
 
         filter.setAuthenticationDetailsSource(headerAuthenticationDetailsSource);
         filter.setAuthenticationManager(authenticationManager());
-        filter.setContinueFilterChainOnUnsuccessfulAuthentication(false);
+        filter.setContinueFilterChainOnUnsuccessfulAuthentication(isDevEnv);
 
         String authorizeUrl = PropertyUtil.get("oskari.authorize.url", "/auth");
 


### PR DESCRIPTION
This can be used to bypass the http header based login on dev env by configuring oskari-ext.properties:
```

# Use hard-coded login for dev env
useDevLogin=true
# This is used to fool spring preauth to take a look at any present header so we can proceed with dummy login
oskari.preauth.username.header=Referer
# THESE CAN BE USED TO SELECT THE USER (for admin/normal user login)
# defaults to dev@oskari.org
#useDevLogin.email=dev@oskari.org
# defaults to dev
#useDevLogin.firstname=dev
# defaults to oskari
#useDevLogin.lastname=oskari
# defaults to dev
#useDevLogin.screenname=dev