### PR TITLE
Add new datasource for postinumero alueet with working title

### DIFF
--- a/app-resources/src/main/resources/flyway/ptistats/V1_54__add_paavo.sql
+++ b/app-resources/src/main/resources/flyway/ptistats/V1_54__add_paavo.sql
@@ -1,0 +1,26 @@
+
+-- datasource for "PxWEB on Tilastokeskus"
+INSERT INTO oskari_statistical_datasource (locale, config, plugin)
+VALUES ('{"fi":{"name":"Tilastokeskus - Postinumero aluejaolla"},"sv":{"name":"Statistikcentralen - Postområden"},"en":{"name":"Statistics Finland - Postal areas"}}',
+'{
+  	"url": "https://pxdata.stat.fi/pxweb/api/v1/fi/Postinumeroalueittainen_avoin_tieto/uusin/paavo_pxt_12f7.px",
+  	"info": {
+  		"url": "http://www.tilastokeskus.fi"
+  	},
+  	"regionKey": "Postinumeroalue",
+  	"indicatorKey": "Tiedot",
+     "hints": {
+       "dimensions": [{
+         "id" : "Vuosi",
+         "sort" : "DESC"
+       }]
+     }
+}', 'PxWEB');
+
+-- link regionset layer
+INSERT INTO
+    oskari_statistical_datasource_regionsets(datasource_id, layer_id)
+VALUES(
+    (SELECT id FROM oskari_statistical_datasource
+        WHERE config like '%Postinumeroalueittainen_avoin_tieto%'),
+    (SELECT id FROM oskari_maplayer WHERE type='statslayer' AND name = 'postialue:pno'));


### PR DESCRIPTION
The regionset layer was added in previous migration for user indicators.

TODO: title of the datasource needs to be updated before going to prod.