### PR TITLE
Replace metadatasearch and featuredata with new impls

### DIFF
--- a/app-resources/src/main/resources/flyway/pti/V3_27_0__replace_featuredata_and_metadatasearch.sql
+++ b/app-resources/src/main/resources/flyway/pti/V3_27_0__replace_featuredata_and_metadatasearch.sql
@@ -1,0 +1,9 @@
+UPDATE oskari_appsetup_bundles
+ SET bundle_id = (select id from oskari_bundle where name='metadatasearch'),
+     bundleinstance = 'metadatasearch'
+ WHERE bundle_id = (select id from oskari_bundle where name='metadatacatalogue');
+
+UPDATE oskari_appsetup_bundles
+ SET bundle_id = (select id from oskari_bundle where name='featuredata'),
+     bundleinstance = 'featuredata'
+ WHERE bundle_id = (select id from oskari_bundle where name='featuredata2');


### PR DESCRIPTION
Also jump the version numbering of migrations to somewhat match the version of the code (next one is 1.27.x).