### PR TITLE
Bump search from 4.1 to 4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <oskari.version>2.13.0-SNAPSHOT</oskari.version>
-        <nls.search.version>4.1</nls.search.version>
+        <nls.search.version>4.2</nls.search.version>
         <nls.proj.version>1.2</nls.proj.version>
         <nls.terrain-profile.version>1.3</nls.terrain-profile.version>
 

--- a/webapp-map/src/main/webapp/WEB-INF/jsp/index.jsp
+++ b/webapp-map/src/main/webapp/WEB-INF/jsp/index.jsp
@@ -247,9 +247,6 @@
             transform: rotate(45deg);
              --%>
         }
-        #demoribbon:hover {
-            display:none;
-        }
         @media (max-width: 600px) {
             #demoribbon {
                 opacity: 0.3;


### PR DESCRIPTION
To get rid of some stack traces in logs for reverse geocoding searches (nearest address).

4.2 is this https://github.com/nlsfi/oskari-server-extras/pull/27