### PR TITLE
Add support for Tomcat

### DIFF
--- a/webapp-map/pom.xml
+++ b/webapp-map/pom.xml
@@ -139,6 +139,11 @@
             <artifactId>postgresql</artifactId>
         </dependency>
 
+        <!-- JSTL not needed for Jetty, but required by Tomcat -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>jstl</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
JSTL is required to be packaged in for Tomcat and doesn't hurt Jetty.