### PR TITLE
Fix region sets for Helsinki statistical data

### DIFF
--- a/app-resources/src/main/resources/flyway/ptistats/V1_61__fix_hki_layers.sql
+++ b/app-resources/src/main/resources/flyway/ptistats/V1_61__fix_hki_layers.sql
@@ -24,21 +24,21 @@ UPDATE oskari_maplayer
 SET
     url = 'https://kartta.hel.fi/ws/geoserver/avoindata/wfs',
     name = 'avoindata:Piirijako_suurpiiri',
-    attributes = '{"statistics":{"regionIdTag":"kokotun","nameIdTag":"nimi"}}'
+    attributes = '{"statistics":{"regionIdTag":"kokotunnus","nameIdTag":"nimi_fi"}}'
 WHERE type='statslayer' AND name = 'hel:Helsinki_suurpiirit';
 
 UPDATE oskari_maplayer
 SET
     url = 'https://kartta.hel.fi/ws/geoserver/avoindata/wfs',
     name = 'avoindata:Piirijako_peruspiiri',
-    attributes = '{"statistics":{"regionIdTag":"kokotun","nameIdTag":"nimi"}}'
+    attributes = '{"statistics":{"regionIdTag":"kokotunnus","nameIdTag":"nimi_fi"}}'
 WHERE type='statslayer' AND name = 'hel:Helsinki_peruspiirit';
 
 UPDATE oskari_maplayer
 SET
     url = 'https://kartta.hel.fi/ws/geoserver/avoindata/wfs',
     name = 'avoindata:Piirijako_osaalue',
-    attributes = '{"statistics":{"regionIdTag":"kokotun","nameIdTag":"nimi"}}'
+    attributes = '{"statistics":{"regionIdTag":"kokotunnus","nameIdTag":"nimi_fi"}}'
 WHERE type='statslayer' AND name = 'seutukartta:Helsinki_osa-alueet';
 
 

--- a/app-resources/src/main/resources/flyway/ptistats/V1_61__fix_hki_layers.sql
+++ b/app-resources/src/main/resources/flyway/ptistats/V1_61__fix_hki_layers.sql
@@ -1,0 +1,22 @@
+-- 'http://geoserver.hel.fi/geoserver/wfs' -> 'https://kartta.hel.fi/ws/geoserver/avoindata/wfs'
+UPDATE oskari_maplayer
+SET
+    url = 'https://kartta.hel.fi/ws/geoserver/avoindata/wfs',
+    name = 'avoindata:Seutukartta_aluejako_pienalue',
+    attributes = '{"statistics":{"featuresUrl": "https://kartta.hel.fi/ws/geoserver/avoindata/wfs","regionIdTag":"kokotun","nameIdTag":"nimi"}}'
+WHERE type='statslayer' AND name = 'seutukartta:Seutu_pienalueet';
+
+UPDATE oskari_maplayer
+SET
+    url = 'https://kartta.hel.fi/ws/geoserver/avoindata/wfs',
+    name = 'avoindata:Seutukartta_aluejako_suuralue',
+    attributes = '{"statistics":{"featuresUrl": "https://kartta.hel.fi/ws/geoserver/avoindata/wfs","regionIdTag":"kokotun","nameIdTag":"nimi"}}'
+WHERE type='statslayer' AND name = 'seutukartta:Seutu_suuralueet';
+
+UPDATE oskari_maplayer
+SET
+    url = 'https://kartta.hel.fi/ws/geoserver/avoindata/wfs',
+    name = 'avoindata:Seutukartta_aluejako_tilastoalue',
+    attributes = '{"statistics":{"featuresUrl": "https://kartta.hel.fi/ws/geoserver/avoindata/wfs","regionIdTag":"kokotun","nameIdTag":"nimi"}}'
+WHERE type='statslayer' AND name = 'seutukartta:Seutu_tilastoalueet';
+

--- a/app-resources/src/main/resources/flyway/ptistats/V1_61__fix_hki_layers.sql
+++ b/app-resources/src/main/resources/flyway/ptistats/V1_61__fix_hki_layers.sql
@@ -3,20 +3,42 @@ UPDATE oskari_maplayer
 SET
     url = 'https://kartta.hel.fi/ws/geoserver/avoindata/wfs',
     name = 'avoindata:Seutukartta_aluejako_pienalue',
-    attributes = '{"statistics":{"featuresUrl": "https://kartta.hel.fi/ws/geoserver/avoindata/wfs","regionIdTag":"kokotun","nameIdTag":"nimi"}}'
+    attributes = '{"statistics":{"regionIdTag":"kokotun","nameIdTag":"nimi"}}'
 WHERE type='statslayer' AND name = 'seutukartta:Seutu_pienalueet';
 
 UPDATE oskari_maplayer
 SET
     url = 'https://kartta.hel.fi/ws/geoserver/avoindata/wfs',
     name = 'avoindata:Seutukartta_aluejako_suuralue',
-    attributes = '{"statistics":{"featuresUrl": "https://kartta.hel.fi/ws/geoserver/avoindata/wfs","regionIdTag":"kokotun","nameIdTag":"nimi"}}'
+    attributes = '{"statistics":{"regionIdTag":"kokotun","nameIdTag":"nimi"}}'
 WHERE type='statslayer' AND name = 'seutukartta:Seutu_suuralueet';
 
 UPDATE oskari_maplayer
 SET
     url = 'https://kartta.hel.fi/ws/geoserver/avoindata/wfs',
     name = 'avoindata:Seutukartta_aluejako_tilastoalue',
-    attributes = '{"statistics":{"featuresUrl": "https://kartta.hel.fi/ws/geoserver/avoindata/wfs","regionIdTag":"kokotun","nameIdTag":"nimi"}}'
+    attributes = '{"statistics":{"regionIdTag":"kokotun","nameIdTag":"nimi"}}'
 WHERE type='statslayer' AND name = 'seutukartta:Seutu_tilastoalueet';
+
+UPDATE oskari_maplayer
+SET
+    url = 'https://kartta.hel.fi/ws/geoserver/avoindata/wfs',
+    name = 'avoindata:Piirijako_suurpiiri',
+    attributes = '{"statistics":{"regionIdTag":"kokotun","nameIdTag":"nimi"}}'
+WHERE type='statslayer' AND name = 'hel:Helsinki_suurpiirit';
+
+UPDATE oskari_maplayer
+SET
+    url = 'https://kartta.hel.fi/ws/geoserver/avoindata/wfs',
+    name = 'avoindata:Piirijako_peruspiiri',
+    attributes = '{"statistics":{"regionIdTag":"kokotun","nameIdTag":"nimi"}}'
+WHERE type='statslayer' AND name = 'hel:Helsinki_peruspiirit';
+
+UPDATE oskari_maplayer
+SET
+    url = 'https://kartta.hel.fi/ws/geoserver/avoindata/wfs',
+    name = 'avoindata:Piirijako_osaalue',
+    attributes = '{"statistics":{"regionIdTag":"kokotun","nameIdTag":"nimi"}}'
+WHERE type='statslayer' AND name = 'seutukartta:Helsinki_osa-alueet';
+
 


### PR DESCRIPTION
Layers have moved from `http://geoserver.hel.fi/geoserver/wfs` to `https://kartta.hel.fi/ws/geoserver/avoindata/wfs` with changes:
- seutukartta:Seutu_pienalueet -> avoindata:Seutukartta_aluejako_pienalue
- seutukartta:Seutu_suuralueet -> avoindata:Seutukartta_aluejako_suuralue
- seutukartta:Seutu_tilastoalueet -> avoindata:Seutukartta_aluejako_tilastoalue
- hel:Helsinki_suurpiirit -> avoindata:Piirijako_suurpiiri
- hel:Helsinki_peruspiirit -> avoindata:Piirijako_peruspiiri
- seutukartta:Helsinki_osa-alueet -> avoindata:Piirijako_osaalue

The last 3 also changed:
- regionIdTag kokotun -> kokotunnus
- nameIdTag nimi -> nimi_fi

Removed featuresUrl as its the same as url for the layer. This change in oskari-server makes it optional:
https://github.com/oskariorg/oskari-server/pull/1054

