### PR TITLE
Drop Helsinki from statistical datasources

### DIFF
--- a/app-resources/src/main/resources/flyway/ptistats/V1_63__drop_hki_datasource.sql
+++ b/app-resources/src/main/resources/flyway/ptistats/V1_63__drop_hki_datasource.sql
@@ -1,0 +1,2 @@
+-- This will remove mappings to region sets as well. We will add HKI again after we have proper mappings to region sets available
+delete from oskari_statistical_datasource where locale like '%City of Helsinki%'


### PR DESCRIPTION
The datasource has many indicators that are not usable to end-users since we don't have the correct region set mappings for them. We'll add HKI back ones we get the region sets figured out to make it more useful for end-users.

Since we intend to add it back in, we don't want to remove the current region sets as they might be used on user indicators. The links between datasource and layers are dropped with the datasource (https://github.com/oskariorg/oskari-server/blob/2.13.0/content-resources/src/main/resources/flyway/oskari/V2_0_1__tables_for_empty_db.sql#L1867-L1868)