### PR TITLE
Remove JSTL refs from landing webapp

### DIFF
--- a/webapp-landing/pom.xml
+++ b/webapp-landing/pom.xml
@@ -24,6 +24,11 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <!-- JSTL not needed for Jetty, but required by Tomcat -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>jstl</artifactId>
+        </dependency>
         <!-- For Java 11 compatibility -->
         <dependency>
             <groupId>javax.annotation</groupId>

--- a/webapp-landing/pom.xml
+++ b/webapp-landing/pom.xml
@@ -24,11 +24,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-        <!-- JSTL not needed for Jetty, but required by Tomcat -->
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>jstl</artifactId>
-        </dependency>
         <!-- For Java 11 compatibility -->
         <dependency>
             <groupId>javax.annotation</groupId>

--- a/webapp-landing/src/main/java/fi/nls/oskari/FriendlyURLHandler.java
+++ b/webapp-landing/src/main/java/fi/nls/oskari/FriendlyURLHandler.java
@@ -1,7 +1,5 @@
 package fi.nls.oskari;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/webapp-landing/src/main/java/fi/nls/oskari/LandingHandler.java
+++ b/webapp-landing/src/main/java/fi/nls/oskari/LandingHandler.java
@@ -27,7 +27,7 @@ public class LandingHandler {
             b.append("?");
             b.append(query);
         }
-        logger404.info(b.toString() + " referer: " + request.getHeader("referer"));
+        logger404.info(b + " referer: " + request.getHeader("referer"));
         return new ModelAndView("redirect:/");
     }
 }

--- a/webapp-landing/src/main/webapp/WEB-INF/jsp/landingpage.jsp
+++ b/webapp-landing/src/main/webapp/WEB-INF/jsp/landingpage.jsp
@@ -1,7 +1,4 @@
 <%@ page contentType="text/html; charset=UTF-8" isELIgnored="false" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
-<%@ taglib prefix="spring" uri="http://www.springframework.org/tags" %>
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
As they are not needed anymore and fixes compatibility with Tomcat.