### PR TITLE
Add JSTL dependency for landing page

### DIFF
--- a/webapp-landing/pom.xml
+++ b/webapp-landing/pom.xml
@@ -24,6 +24,11 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <!-- JSTL not needed for Jetty, but required by Tomcat -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>jstl</artifactId>
+        </dependency>
         <!-- For Java 11 compatibility -->
         <dependency>
             <groupId>javax.annotation</groupId>


### PR DESCRIPTION
Seems it's required anyways. Otherwise this gets thrown:

```
DEBUG org.springframework.web.servlet.view.JstlView - View name 'landingpage', model {}
TRACE org.springframework.web.servlet.DispatcherServlet - Failed to complete request
org.springframework.web.util.NestedServletException: Handler processing failed; nested exception is java.lang.NoClassDefFoundError: javax/servlet/jsp/jstl/core/Config
Caused by: java.lang.NoClassDefFoundError: javax/servlet/jsp/jstl/core/Config
        at org.springframework.web.servlet.support.JstlUtils.exposeLocalizationContext(JstlUtils.java:103)