### PR TITLE
Fix request mapping for Spring 6/Java 17

### DIFF
--- a/service-coordtransform/src/main/java/fi/nls/oskari/spring/CoordinateTransformationAsyncController.java
+++ b/service-coordtransform/src/main/java/fi/nls/oskari/spring/CoordinateTransformationAsyncController.java
@@ -51,7 +51,8 @@ public class CoordinateTransformationAsyncController {
         this.worker = OskariComponentManager.getComponentOfType(CoordTransWorker.class);
     }
 
-    @RequestMapping(ROUTE + "/{jobId}")
+    // Using ROUTE + "/{jobId}" as RequestMapping value no longer works with Spring 6
+    @RequestMapping("/coordinatetransform/watch/{jobId}")
     public @ResponseBody DeferredResult<CoordinatesPayload> watchJob(@PathVariable("jobId") String jobId, @OskariParam ActionParameters params) {
         if (jobId == null) {
             handleActionParamsException(new ActionParamsException(


### PR DESCRIPTION
Using constant as part of RequestMapping value doesn't work anymore with the latest codebase. Using the ROUTE variable makes the `/coordinatetransform/watch/*` return 404 Not Found.

Fixes coordinate transformation service.