### PR TITLE
KOMU: Add a proxying route and allow bundle config with oskari-ext.properties

### DIFF
--- a/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/KomuBundleHandler.java
+++ b/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/KomuBundleHandler.java
@@ -9,7 +9,7 @@ import fi.nls.oskari.view.modifier.ModifierParams;
 import org.json.JSONObject;
 
 /**
- * Injects possible url for frontend in komu config
+ * Injects an optional alternative url for frontend to use through bundle config
 
  {
  "url": "/action/KomuProj"
@@ -20,16 +20,16 @@ public class KomuBundleHandler extends BundleHandler {
 
     public boolean modifyBundle(final ModifierParams params) throws ModifierException {
         final JSONObject config = getBundleConfig(params.getConfig());
-        JSONHelper.putValue(config, "url", isFrontendUrl());
+        JSONHelper.putValue(config, "url", getAltFrontendUrl());
         return false;
     }
 
     /**
-     * If users are managed in external source any changes to them are usually overwritten when they login.
-     * So we can disable the fields that are and updates that can happen to users to make the admin UI more user-friendly.
+     * Allows configuring an alternative frontend URL for the frontend to use when calling the server.
+     * Either a path to a new route on this server (/action/KomuProj) or a whole URL to another service (komu backend)
      * @return
      */
-    public static String isFrontendUrl() {
+    public static String getAltFrontendUrl() {
         return PropertyUtil.getOptional("pti.komu.frontendUrl");
     }
 }

--- a/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/KomuBundleHandler.java
+++ b/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/KomuBundleHandler.java
@@ -1,0 +1,35 @@
+package fi.nls.paikkatietoikkuna.coordtransform;
+
+import fi.nls.oskari.annotation.OskariViewModifier;
+import fi.nls.oskari.control.view.modifier.bundle.BundleHandler;
+import fi.nls.oskari.util.JSONHelper;
+import fi.nls.oskari.util.PropertyUtil;
+import fi.nls.oskari.view.modifier.ModifierException;
+import fi.nls.oskari.view.modifier.ModifierParams;
+import org.json.JSONObject;
+
+/**
+ * Injects possible url for frontend in komu config
+
+ {
+ "url": "/action/KomuProj"
+ }
+ */
+@OskariViewModifier("coordinatetransformation")
+public class KomuBundleHandler extends BundleHandler {
+
+    public boolean modifyBundle(final ModifierParams params) throws ModifierException {
+        final JSONObject config = getBundleConfig(params.getConfig());
+        JSONHelper.putValue(config, "url", isFrontendUrl());
+        return false;
+    }
+
+    /**
+     * If users are managed in external source any changes to them are usually overwritten when they login.
+     * So we can disable the fields that are and updates that can happen to users to make the admin UI more user-friendly.
+     * @return
+     */
+    public static String isFrontendUrl() {
+        return PropertyUtil.getOptional("pti.komu.frontendUrl");
+    }
+}

--- a/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/KomuProjActionHandler.java
+++ b/service-coordtransform/src/main/java/fi/nls/paikkatietoikkuna/coordtransform/KomuProjActionHandler.java
@@ -1,0 +1,76 @@
+package fi.nls.paikkatietoikkuna.coordtransform;
+
+import fi.nls.oskari.control.ActionCommonException;
+import fi.nls.oskari.log.LogFactory;
+import fi.nls.oskari.log.Logger;
+import fi.nls.oskari.util.IOHelper;
+import fi.nls.oskari.annotation.OskariActionRoute;
+import fi.nls.oskari.control.ActionException;
+import fi.nls.oskari.control.ActionParameters;
+import fi.nls.oskari.control.RestActionHandler;
+import fi.nls.oskari.util.PropertyUtil;
+
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.util.Iterator;
+
+
+/**
+ * Proxies KomuProj action_route requests
+ */
+@OskariActionRoute("KomuProj")
+public class KomuProjActionHandler extends RestActionHandler {
+
+    private static final String PROP_END_POINT = "coordtransform.endpoint";
+    private static final Logger LOG = LogFactory.getLogger(KomuProjActionHandler.class);
+
+
+    private String endPoint;
+
+    public KomuProjActionHandler() {
+        this(null);
+    }
+
+    protected KomuProjActionHandler(String endPoint) {
+        this.endPoint = endPoint;
+    }
+
+    @Override
+    public void init() {
+        if (endPoint == null) {
+            endPoint = PropertyUtil.getNecessary(PROP_END_POINT);
+        }
+    }
+
+    @Override
+    public void handlePost(ActionParameters params) throws ActionException {
+        try {
+            HttpURLConnection conn = getConnection(params);
+
+            IOHelper.copy(params.getRequest().getInputStream(), conn.getOutputStream());
+            if (conn.getResponseCode() != 200) {
+                if (LOG.isDebugEnabled()) {
+                    // don't read if debug is not enabled
+                    LOG.debug("Response was:", IOHelper.readString(conn.getInputStream()));
+                }
+                throw new ActionCommonException("Got non-OK response");
+            }
+            IOHelper.readBytesTo(conn, params.getResponse().getOutputStream());
+
+        } catch (IOException e) {
+            throw new ActionCommonException("Unable to proxy to proj", e);
+        }
+    }
+
+    private HttpURLConnection getConnection(ActionParameters params) throws IOException {
+        String queryParams = IOHelper.getParamsMultiValue(params.getRequest().getParameterMap());
+        String url = IOHelper.addQueryString(endPoint, queryParams);
+        HttpURLConnection conn = IOHelper.getConnection(url);
+        conn.setRequestMethod("POST");
+        conn.setDoOutput(true);
+        conn.setDoInput(true);
+        IOHelper.setContentType(conn, "text/plain");
+
+        return conn;
+    }
+}


### PR DESCRIPTION
Configure:
```
pti.komu.frontendUrl=/action/KomuProj
```
to make the frontend call the proxying route.